### PR TITLE
fix(resolve): trust GitHub's mergeable status; force re-eval on stale-cache

### DIFF
--- a/src/pr.ts
+++ b/src/pr.ts
@@ -7,6 +7,64 @@ export interface PrResult {
   action: "created" | "updated"
 }
 
+/**
+ * GitHub's authoritative answer to "can this PR be merged?" — single
+ * source of truth, no local-vs-remote drift.
+ *
+ * Surfaced separately from the local `mergeBase` action so callers can:
+ *   1. Ask GitHub first ("is there a real conflict to resolve?")
+ *   2. Only attempt a local merge when GitHub confirms a conflict.
+ *
+ * Mapping:
+ *   - `MERGEABLE`     — gh: mergeable=MERGEABLE, no conflicts; safe to merge.
+ *   - `CONFLICTING`   — gh: mergeable=CONFLICTING; resolve required.
+ *   - `BLOCKED`       — gh: mergeable=MERGEABLE but mergeStateStatus=BLOCKED
+ *                       (failing checks, missing reviews, etc.) — no resolve work.
+ *   - `UNKNOWN`       — gh hasn't computed yet (race); caller should retry.
+ *   - `ERROR`         — gh call failed; caller decides whether to retry/bail.
+ *
+ * Replaces ad-hoc `gh pr view ... --json mergeable,mergeStateStatus` calls
+ * scattered across syncFlow / resolveFlow / mergeReadyTaskPRs / etc.
+ */
+export type PrMergeStatus = "MERGEABLE" | "CONFLICTING" | "BLOCKED" | "UNKNOWN" | "ERROR"
+
+export interface PrMergeInfo {
+  status: PrMergeStatus
+  /** Raw `mergeable` value from gh (`MERGEABLE` | `CONFLICTING` | `UNKNOWN`). */
+  mergeable: string
+  /** Raw `mergeStateStatus` from gh (`CLEAN` | `DIRTY` | `BLOCKED` | `BEHIND` | `UNSTABLE` | `UNKNOWN`). */
+  mergeStateStatus: string
+}
+
+export function prMergeStatus(prNumber: number, cwd?: string): PrMergeInfo {
+  try {
+    const out = gh(
+      ["pr", "view", String(prNumber), "--json", "mergeable,mergeStateStatus"],
+      { cwd },
+    )
+    const parsed = JSON.parse(out) as { mergeable?: string; mergeStateStatus?: string }
+    const mergeable = parsed.mergeable ?? "UNKNOWN"
+    const mergeStateStatus = parsed.mergeStateStatus ?? "UNKNOWN"
+    return { status: classifyMergeStatus(mergeable, mergeStateStatus), mergeable, mergeStateStatus }
+  } catch {
+    return { status: "ERROR", mergeable: "", mergeStateStatus: "" }
+  }
+}
+
+function classifyMergeStatus(mergeable: string, mergeStateStatus: string): PrMergeStatus {
+  if (mergeable === "CONFLICTING") return "CONFLICTING"
+  if (mergeable === "UNKNOWN") return "UNKNOWN"
+  if (mergeable === "MERGEABLE") {
+    if (mergeStateStatus === "CLEAN") return "MERGEABLE"
+    if (mergeStateStatus === "DIRTY") return "CONFLICTING"
+    // BLOCKED, BEHIND, UNSTABLE, UNKNOWN — mergeable in principle but
+    // gated by external policy. Resolve has nothing to do; sync/CI
+    // belongs in a different flow.
+    return "BLOCKED"
+  }
+  return "UNKNOWN"
+}
+
 export interface EnsurePrOptions {
   branch: string
   defaultBranch: string

--- a/src/scripts/resolveFlow.ts
+++ b/src/scripts/resolveFlow.ts
@@ -1,8 +1,23 @@
 /**
  * Flow script for the `resolve` executable.
- * Loads PR, checks it out, attempts to merge origin/<base>. On clean merge,
- * sets ctx.skipAgent = true and marks success. On conflict, collects the
- * conflicted files + markers preview for the agent to resolve.
+ *
+ * GitHub's `mergeable` field is the authoritative source of truth for
+ * "is there a conflict?" We consult it FIRST. The local `git merge` is
+ * an action (collecting conflict markers), not a status check —
+ * separating the two avoids the bug we hit on A-Guy #1525 where the
+ * local merge said "Already up to date" but GitHub still reported
+ * CONFLICTING (its mergeable cache was stale relative to a prior sync).
+ *
+ * Decision table:
+ *   - GitHub `MERGEABLE`     → nothing to resolve; courtesy comment + exit.
+ *   - GitHub `BLOCKED`       → mergeable in principle but gated by checks/
+ *                              reviews; resolve has no work; comment + exit.
+ *   - GitHub `CONFLICTING`   → run local `git merge`; if it produces
+ *                              conflicts, hand to the agent; if it's
+ *                              clean (stale cache), push an empty commit
+ *                              to force GitHub to re-evaluate.
+ *   - GitHub `UNKNOWN`/`ERROR` → fall through to local merge; treat as
+ *                              best-effort (preserves prior behavior).
  */
 
 import { execFileSync } from "node:child_process"
@@ -10,6 +25,7 @@ import { checkoutPrBranch, getCurrentBranch, mergeBase } from "../branch.js"
 import type { PreflightScript } from "../executables/types.js"
 import { getRunUrl } from "../gha.js"
 import { getPr, postPrReviewComment } from "../issue.js"
+import { prMergeStatus } from "../pr.js"
 
 const CONFLICT_DIFF_MAX_BYTES = 40_000
 
@@ -26,14 +42,47 @@ export const resolveFlow: PreflightScript = async (ctx) => {
   ctx.data.commentTargetType = "pr"
   ctx.data.commentTargetNumber = prNumber
 
-  checkoutPrBranch(prNumber, ctx.cwd)
-  ctx.data.branch = getCurrentBranch(ctx.cwd)
-
   const baseBranch = pr.baseRefName || ctx.config.git.defaultBranch
   ctx.data.baseBranch = baseBranch
 
+  // Ask GitHub first — single source of truth for "is there a conflict?"
+  const ghStatus = prMergeStatus(prNumber, ctx.cwd)
+
+  if (ghStatus.status === "MERGEABLE") {
+    ctx.output.exitCode = 0
+    ctx.output.reason = `PR #${prNumber} is mergeable (no conflicts) — nothing to resolve`
+    ctx.skipAgent = true
+    tryPostPr(prNumber, `ℹ️ kody resolve: ${ctx.output.reason}`, ctx.cwd)
+    return
+  }
+  if (ghStatus.status === "BLOCKED") {
+    ctx.output.exitCode = 0
+    ctx.output.reason = `PR #${prNumber} is mergeable but blocked by checks/reviews (mergeStateStatus=${ghStatus.mergeStateStatus}) — nothing for resolve to do`
+    ctx.skipAgent = true
+    tryPostPr(prNumber, `ℹ️ kody resolve: ${ctx.output.reason}`, ctx.cwd)
+    return
+  }
+
+  // CONFLICTING / UNKNOWN / ERROR — proceed with local merge.
+  checkoutPrBranch(prNumber, ctx.cwd)
+  ctx.data.branch = getCurrentBranch(ctx.cwd)
+
   const mergeStatus = mergeBase(baseBranch, ctx.cwd)
   if (mergeStatus === "clean") {
+    // GitHub said CONFLICTING but local merge is clean — likely a stale
+    // mergeable cache on GitHub's side. Push an empty commit to force
+    // GitHub to re-evaluate; next auto-resolve tick will see MERGEABLE
+    // and skip. Best-effort — failure is non-fatal.
+    if (ghStatus.status === "CONFLICTING") {
+      const pushed = pushEmptyCommit(ctx.data.branch as string, ctx.cwd)
+      ctx.output.exitCode = 0
+      ctx.output.reason = pushed
+        ? `local merge clean despite GitHub reporting CONFLICTING — pushed empty commit to force re-evaluation`
+        : `local merge clean despite GitHub reporting CONFLICTING — couldn't refresh GitHub cache (push failed)`
+      ctx.skipAgent = true
+      tryPostPr(prNumber, `ℹ️ kody resolve: ${ctx.output.reason}`, ctx.cwd)
+      return
+    }
     ctx.output.exitCode = 0
     ctx.output.reason = `already up to date with origin/${baseBranch} — nothing to resolve`
     ctx.skipAgent = true
@@ -124,5 +173,30 @@ function tryPostPr(prNumber: number, body: string, cwd?: string): void {
     postPrReviewComment(prNumber, body, cwd)
   } catch {
     /* best effort */
+  }
+}
+
+/**
+ * Push an empty commit on the PR branch to force GitHub to recompute
+ * its `mergeable` status. Used when GitHub's cached status disagrees
+ * with the local merge result. Best-effort; returns whether the push
+ * succeeded so the caller can phrase its log message correctly.
+ */
+function pushEmptyCommit(branch: string, cwd?: string): boolean {
+  const env = { ...process.env, HUSKY: "0", SKIP_HOOKS: "1" }
+  try {
+    execFileSync(
+      "git",
+      ["commit", "--allow-empty", "-m", "chore: kody resolve refresh — empty commit to recompute mergeable status"],
+      { cwd, env, stdio: ["ignore", "pipe", "pipe"] },
+    )
+    execFileSync("git", ["push", "-u", "origin", branch], {
+      cwd,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+    return true
+  } catch {
+    return false
   }
 }

--- a/tests/unit/prMergeStatus.test.ts
+++ b/tests/unit/prMergeStatus.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("../../src/issue.js", () => ({
+  gh: vi.fn(),
+  truncate: (s: string) => s,
+}))
+
+import { gh } from "../../src/issue.js"
+import { prMergeStatus } from "../../src/pr.js"
+
+const ghMock = gh as unknown as ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  ghMock.mockReset()
+})
+
+describe("prMergeStatus", () => {
+  it("MERGEABLE + CLEAN → MERGEABLE", () => {
+    ghMock.mockReturnValue(JSON.stringify({ mergeable: "MERGEABLE", mergeStateStatus: "CLEAN" }))
+    expect(prMergeStatus(1).status).toBe("MERGEABLE")
+  })
+
+  it("CONFLICTING → CONFLICTING (regardless of mergeStateStatus)", () => {
+    ghMock.mockReturnValue(JSON.stringify({ mergeable: "CONFLICTING", mergeStateStatus: "DIRTY" }))
+    expect(prMergeStatus(1).status).toBe("CONFLICTING")
+  })
+
+  it("MERGEABLE + DIRTY → CONFLICTING (covers GitHub mismatched-cache edge case)", () => {
+    ghMock.mockReturnValue(JSON.stringify({ mergeable: "MERGEABLE", mergeStateStatus: "DIRTY" }))
+    expect(prMergeStatus(1).status).toBe("CONFLICTING")
+  })
+
+  it("MERGEABLE + BLOCKED/BEHIND/UNSTABLE → BLOCKED", () => {
+    for (const mss of ["BLOCKED", "BEHIND", "UNSTABLE", "UNKNOWN"]) {
+      ghMock.mockReturnValue(JSON.stringify({ mergeable: "MERGEABLE", mergeStateStatus: mss }))
+      expect(prMergeStatus(1).status).toBe("BLOCKED")
+    }
+  })
+
+  it("UNKNOWN → UNKNOWN", () => {
+    ghMock.mockReturnValue(JSON.stringify({ mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" }))
+    expect(prMergeStatus(1).status).toBe("UNKNOWN")
+  })
+
+  it("gh failure → ERROR with empty raw fields", () => {
+    ghMock.mockImplementation(() => {
+      throw new Error("boom")
+    })
+    const r = prMergeStatus(1)
+    expect(r.status).toBe("ERROR")
+    expect(r.mergeable).toBe("")
+    expect(r.mergeStateStatus).toBe("")
+  })
+
+  it("returns raw fields alongside the classification", () => {
+    ghMock.mockReturnValue(JSON.stringify({ mergeable: "CONFLICTING", mergeStateStatus: "DIRTY" }))
+    const r = prMergeStatus(1)
+    expect(r.mergeable).toBe("CONFLICTING")
+    expect(r.mergeStateStatus).toBe("DIRTY")
+  })
+
+  it("invokes gh with the correct args", () => {
+    ghMock.mockReturnValue(JSON.stringify({ mergeable: "MERGEABLE", mergeStateStatus: "CLEAN" }))
+    prMergeStatus(123, "/repo")
+    expect(ghMock).toHaveBeenCalledWith(
+      ["pr", "view", "123", "--json", "mergeable,mergeStateStatus"],
+      { cwd: "/repo" },
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the kody resolve / auto-resolve disagreement bug surfaced on A-Guy goal PR #1525, where GitHub reported `mergeable: CONFLICTING` but `kody resolve` repeatedly said "already up to date — nothing to resolve" because the local `git merge` direction differs from GitHub's authoritative check.

## Changes

- New `prMergeStatus()` helper in `src/pr.ts` — single source of truth for "is this PR mergeable?" using GitHub's authoritative API.
- `resolveFlow` queries that helper first; only falls back to local merge for `CONFLICTING`/`UNKNOWN`/`ERROR`. On stale-cache mismatches (GitHub says CONFLICTING but local merge is clean), pushes an empty commit to force GitHub to recompute `mergeable`.
- 8 unit tests covering every classification branch.

See commit message for detailed reasoning.

## Test plan

- [x] typecheck clean
- [x] `prMergeStatus` unit tests pass
- [ ] Live test on Kody-Engine-Tester after publish — set up a real conflict, run `@kody resolve`, verify the new path either resolves or surfaces the failure cleanly with raw gh fields in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)