### PR TITLE
#32: smoke: validate unified job model on @next

### DIFF
--- a/src/servers/serve.ts
+++ b/src/servers/serve.ts
@@ -35,7 +35,7 @@ export interface ServeOptions {
 
 type EditorTarget = "none" | "vscode" | "claude"
 
-function parseTarget(positional: unknown): EditorTarget {
+export function parseTarget(positional: unknown): EditorTarget {
   if (!Array.isArray(positional) || positional.length === 0) return "none"
   const first = String(positional[0]).toLowerCase()
   if (first === "vscode" || first === "code") return "vscode"
@@ -43,7 +43,7 @@ function parseTarget(positional: unknown): EditorTarget {
   throw new Error(`unknown serve subcommand: "${positional[0]}" (expected: vscode, claude, or omit)`)
 }
 
-function buildProxyEnv(url: string): NodeJS.ProcessEnv {
+export function buildProxyEnv(url: string): NodeJS.ProcessEnv {
   return {
     ...process.env,
     ANTHROPIC_BASE_URL: url,

--- a/tests/smoke/job-model.test.ts
+++ b/tests/smoke/job-model.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Smoke (unified job model): validates that `runJob` correctly lowers an
+ * instant job (minted from a dispatch result) onto `runExecutableChain`,
+ * exercising the one-runner path end-to-end with no network.
+ *
+ * Pattern mirrors tests/smoke/flow.test.ts — offline fixture executable,
+ * KODY_SKIP_AGENT=true skips the agent, postflight records the outcome.
+ */
+
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import { mintInstantJob, runJob, validateJob } from "../../src/job.js"
+
+let prevCwd = process.cwd()
+afterEach(() => process.chdir(prevCwd))
+
+/**
+ * Scaffold a temp project with a no-agent echo executable and a minimal
+ * kody.config.json (required by loadConfig in runExecutable). The executable
+ * name matches the "run" dispatch so mintInstantJob sets executable:"smoke-echo"
+ * and runJob dispatches to it.
+ */
+function makeEchoExecutable(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "kody-smoke-job-"))
+  const dir = path.join(root, ".kody", "executables", "smoke-echo")
+  fs.mkdirSync(dir, { recursive: true })
+  const profile = {
+    name: "smoke-echo",
+    role: "utility",
+    describe: "offline smoke fixture: shell preflight skips the agent",
+    kind: "oneshot",
+    inputs: [{ name: "issue", flag: "--issue", type: "int", required: true, describe: "ignored" }],
+    claudeCode: {
+      model: "inherit",
+      permissionMode: "default",
+      maxTurns: 0,
+      maxThinkingTokens: null,
+      systemPromptAppend: null,
+      tools: [],
+      hooks: [],
+      skills: [],
+      commands: [],
+      subagents: [],
+      plugins: [],
+      mcpServers: [],
+    },
+    cliTools: [],
+    scripts: { preflight: [{ shell: "skip.sh" }], postflight: [] },
+  }
+  fs.writeFileSync(path.join(dir, "profile.json"), JSON.stringify(profile, null, 2))
+  fs.writeFileSync(path.join(dir, "skip.sh"), "#!/usr/bin/env bash\necho 'KODY_SKIP_AGENT=true'\n")
+  // Minimal config required by loadConfig in runExecutable
+  fs.writeFileSync(
+    path.join(root, "kody.config.json"),
+    JSON.stringify({
+      agent: { model: "claude/claude-haiku-4-5-20251001" },
+      github: { owner: "test-owner", repo: "test-repo" },
+      quality: {},
+    }),
+  )
+  return root
+}
+
+describe("smoke: unified job model — instant job runs end-to-end via runJob", () => {
+  it("runJob lowers a mintInstantJob dispatch result onto runExecutableChain and exits 0", async () => {
+    prevCwd = process.cwd()
+    const root = makeEchoExecutable()
+    process.chdir(root)
+
+    // Dispatch result simulating what the comment-router produces for `@kody run --issue 42`
+    const dispatch = { executable: "smoke-echo", cliArgs: { issue: 42 }, target: 42 }
+    const job = mintInstantJob(dispatch, { why: "smoke test intent" })
+
+    expect(job.executable).toBe("smoke-echo")
+    expect(job.flavor).toBe("instant")
+    expect(job.cliArgs).toEqual({ issue: 42 })
+    expect(job.why).toBe("smoke test intent")
+    expect(job.persona).toBe("kody") // DEFAULT_INSTANT_PERSONA
+
+    // runJob with chain:true (default) uses runExecutableChain
+    const result = await runJob(job, { cwd: root, chain: true })
+    expect(result.exitCode).toBe(0)
+  })
+
+  it("runJob with chain:false uses runExecutable (single-shot) — exits 0", async () => {
+    prevCwd = process.cwd()
+    const root = makeEchoExecutable()
+    process.chdir(root)
+
+    const dispatch = { executable: "smoke-echo", cliArgs: { issue: 1 }, target: 1 }
+    const job = mintInstantJob(dispatch)
+
+    // chain:false paths bypass runExecutableChain; used by the cron tick route
+    const result = await runJob(job, { cwd: root, chain: false })
+    expect(result.exitCode).toBe(0)
+  })
+
+  it("validateJob rejects a job with neither executable nor duty", () => {
+    expect(() => validateJob({ cliArgs: {}, flavor: "instant" })).toThrow()
+  })
+
+  it("validateJob rejects an unknown flavor", () => {
+    expect(() => validateJob({ executable: "run", cliArgs: {}, flavor: "bogus" })).toThrow()
+  })
+})

--- a/tests/unit/serve.test.ts
+++ b/tests/unit/serve.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for src/servers/serve.ts
+ *
+ * Covers the serve CLI flow preflight: parseTarget and buildProxyEnv helpers,
+ * plus the exported ServeOptions interface.
+ */
+
+import { afterEach, describe, expect, it } from "vitest"
+import { buildProxyEnv, parseTarget, type ServeOptions } from "../../src/servers/serve.js"
+
+describe("parseTarget", () => {
+  it("returns 'none' when positional is empty", () => {
+    expect(parseTarget([])).toBe("none")
+    expect(parseTarget(null)).toBe("none")
+    expect(parseTarget(undefined)).toBe("none")
+  })
+
+  it("returns 'none' when positional is not an array", () => {
+    expect(parseTarget("vscode")).toBe("none")
+    expect(parseTarget({})).toBe("none")
+    expect(parseTarget(123)).toBe("none")
+  })
+
+  it("returns 'none' for an empty array", () => {
+    expect(parseTarget([])).toBe("none")
+  })
+
+  it("returns 'vscode' for 'vscode'", () => {
+    expect(parseTarget(["vscode"])).toBe("vscode")
+  })
+
+  it("returns 'vscode' for 'code' (alias)", () => {
+    expect(parseTarget(["code"])).toBe("vscode")
+  })
+
+  it("returns 'claude' for 'claude'", () => {
+    expect(parseTarget(["claude"])).toBe("claude")
+  })
+
+  it("is case-insensitive for vscode/code", () => {
+    expect(parseTarget(["VSCODE"])).toBe("vscode")
+    expect(parseTarget(["Code"])).toBe("vscode")
+  })
+
+  it("is case-insensitive for claude", () => {
+    expect(parseTarget(["Claude"])).toBe("claude")
+    expect(parseTarget(["CLAUDE"])).toBe("claude")
+  })
+
+  it("throws for an unknown subcommand", () => {
+    expect(() => parseTarget(["emacs"])).toThrow('unknown serve subcommand: "emacs" (expected: vscode, claude, or omit)')
+    expect(() => parseTarget(["npx"])).toThrow()
+  })
+
+  it("ignores extra positional args after the first", () => {
+    expect(parseTarget(["vscode", "extra"])).toBe("vscode")
+    expect(parseTarget(["claude", "arg"])).toBe("claude")
+  })
+})
+
+describe("buildProxyEnv", () => {
+  const ORIGINAL_ENV = { ...process.env }
+
+  afterEach(() => {
+    // Reset env after each test
+    process.env = { ...ORIGINAL_ENV }
+  })
+
+  it("sets ANTHROPIC_BASE_URL to the given url", () => {
+    const env = buildProxyEnv("http://localhost:4000")
+    expect(env["ANTHROPIC_BASE_URL"]).toBe("http://localhost:4000")
+  })
+
+  it("sets ANTHROPIC_API_KEY from the current environment", () => {
+    process.env["ANTHROPIC_API_KEY"] = "my-key"
+    const env = buildProxyEnv("http://localhost:4000")
+    expect(env["ANTHROPIC_API_KEY"]).toBe("my-key")
+  })
+
+  it("preserves other environment variables", () => {
+    process.env["PATH"] = "/usr/bin"
+    process.env["HOME"] = "/root"
+    const env = buildProxyEnv("http://localhost:4000")
+    expect(env["PATH"]).toBe("/usr/bin")
+    expect(env["HOME"]).toBe("/root")
+  })
+})
+
+describe("ServeOptions interface", () => {
+  it("accepts a valid ServeOptions shape", () => {
+    const opts: ServeOptions = {
+      cwd: "/tmp",
+      config: {
+        quality: { typecheck: "tsc", lint: "eslint", format: "prettier", testUnit: "vitest" },
+        git: { defaultBranch: "main" },
+        github: { owner: "acme", repo: "widgets" },
+        agent: { model: "anthropic/claude-haiku-4-5-20251001" },
+      },
+      args: [],
+    }
+    expect(opts.cwd).toBe("/tmp")
+    expect(opts.args).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

- Added `tests/unit/serve.test.ts` — 14 tests covering `parseTarget` (editor target parsing, case sensitivity, aliases, error cases) and `buildProxyEnv` (env var injection) from `src/servers/serve.ts`
- Exported `parseTarget` and `buildProxyEnv` from `src/servers/serve.ts` to make them directly testable (satisfies the coverage floor guard requiring sibling tests for each untested file)

## Changes

- `src/servers/serve.ts`
- `tests/smoke/job-model.test.ts`
- `tests/unit/serve.test.ts`

Closes #32

---
_Opened by kody (single-session autonomous run)._ 