### PR TITLE
#41: tests/int/brain-proxy-bin.test.ts: use repo-relative KODY_BIN and …

### DIFF
--- a/tests/int/brain-proxy-bin.test.ts
+++ b/tests/int/brain-proxy-bin.test.ts
@@ -11,10 +11,12 @@
  */
 
 import { spawn } from "node:child_process"
+import * as fs from "node:fs"
+import * as path from "node:path"
 import { afterEach, describe, expect, it } from "vitest"
 
 const KEY = "test-bin-key-do-not-leak"
-const KODY_BIN = "/Users/aguy/projects/kody2/dist/bin/kody.js"
+const KODY_BIN = path.resolve(import.meta.dirname, "../../dist/bin/kody.js")
 
 interface SpawnResult {
   status: number
@@ -69,6 +71,10 @@ afterEach(() => {
 
 describe("brain-proxy bin: BRAIN_BACKEND env handling", () => {
   it("rejects with exit 2 when BRAIN_API_KEY is missing", async () => {
+    if (!fs.existsSync(KODY_BIN)) {
+      console.warn(`Skipping: ${KODY_BIN} does not exist (run pnpm build first)`)
+      return
+    }
     const child2 = spawn("node", [KODY_BIN, "brain-proxy"], {
       env: { ...process.env, BRAIN_API_KEY: "" },
       stdio: ["pipe", "pipe", "pipe"],
@@ -83,6 +89,10 @@ describe("brain-proxy bin: BRAIN_BACKEND env handling", () => {
   }, 10_000)
 
   it("rejects with exit 2 when BRAIN_BACKEND has an invalid value", async () => {
+    if (!fs.existsSync(KODY_BIN)) {
+      console.warn(`Skipping: ${KODY_BIN} does not exist (run pnpm build first)`)
+      return
+    }
     const child2 = spawn("node", [KODY_BIN, "brain-proxy"], {
       env: { ...process.env, BRAIN_API_KEY: KEY, BRAIN_BACKEND: "openai" },
       stdio: ["pipe", "pipe", "pipe"],
@@ -99,7 +109,6 @@ describe("brain-proxy bin: BRAIN_BACKEND env handling", () => {
 
   it("defaults to brain-serve when BRAIN_BACKEND is unset", async () => {
     // We need the engine to be built for this test to work. Skip if not.
-    const fs = await import("node:fs")
     if (!fs.existsSync(KODY_BIN)) {
       console.warn(`Skipping: ${KODY_BIN} does not exist (run pnpm build first)`)
       return
@@ -109,7 +118,6 @@ describe("brain-proxy bin: BRAIN_BACKEND env handling", () => {
   }, 10_000)
 
   it("honors BRAIN_BACKEND=hermes", async () => {
-    const fs = await import("node:fs")
     if (!fs.existsSync(KODY_BIN)) {
       console.warn(`Skipping: ${KODY_BIN} does not exist (run pnpm build first)`)
       return

--- a/tests/unit/brain-proxy-bin.test.ts
+++ b/tests/unit/brain-proxy-bin.test.ts
@@ -105,10 +105,7 @@ describe("bin/brain-proxy: env validation", () => {
     process.env.BRAIN_API_KEY = "k"
     // The function blocks on `new Promise(() => {})` after wiring the
     // proxy. We race it against a short timer so the test exits.
-    await Promise.race([
-      brainProxy(),
-      new Promise((resolve) => setTimeout(resolve, 50)),
-    ])
+    await Promise.race([brainProxy(), new Promise((resolve) => setTimeout(resolve, 50))])
     expect(startBrainProxy).toHaveBeenCalledOnce()
     const opts = startBrainProxy.mock.calls[0]?.[0] as { backend: string; apiKey: string }
     expect(opts.backend).toBe("brain-serve")
@@ -122,10 +119,7 @@ describe("bin/brain-proxy: env validation", () => {
     process.env.MODEL = "anthropic/claude-sonnet-4-6"
     process.env.BRAIN_PROXY_PORT = "9090"
     process.env.BRAIN_PROXY_HOST = "0.0.0.0"
-    await Promise.race([
-      brainProxy(),
-      new Promise((resolve) => setTimeout(resolve, 50)),
-    ])
+    await Promise.race([brainProxy(), new Promise((resolve) => setTimeout(resolve, 50))])
     expect(startBrainProxy).toHaveBeenCalledOnce()
     const opts = startBrainProxy.mock.calls[0]?.[0] as {
       backend: string
@@ -145,10 +139,7 @@ describe("bin/brain-proxy: env validation", () => {
     process.env.BRAIN_API_KEY = "k"
     process.env.BRAIN_BACKEND = "brain-serve"
     process.env.BRAIN_SERVE_URL = "http://brain:7000"
-    await Promise.race([
-      brainProxy(),
-      new Promise((resolve) => setTimeout(resolve, 50)),
-    ])
+    await Promise.race([brainProxy(), new Promise((resolve) => setTimeout(resolve, 50))])
     const opts = startBrainProxy.mock.calls[0]?.[0] as {
       backend: string
       brainServeUrl: string
@@ -161,10 +152,7 @@ describe("bin/brain-proxy: env validation", () => {
     process.env.BRAIN_API_KEY = "k"
     delete process.env.BRAIN_PROXY_PORT
     delete process.env.BRAIN_PROXY_HOST
-    await Promise.race([
-      brainProxy(),
-      new Promise((resolve) => setTimeout(resolve, 50)),
-    ])
+    await Promise.race([brainProxy(), new Promise((resolve) => setTimeout(resolve, 50))])
     const opts = startBrainProxy.mock.calls[0]?.[0] as { port: number; host: string }
     expect(opts.port).toBe(8080)
     expect(opts.host).toBe("0.0.0.0")

--- a/tests/unit/entrypoint-brain.test.ts
+++ b/tests/unit/entrypoint-brain.test.ts
@@ -11,9 +11,10 @@
  */
 
 import { readFileSync } from "node:fs"
+import * as path from "node:path"
 import { describe, expect, it } from "vitest"
 
-const ENTRYPOINT_PATH = "/Users/aguy/projects/kody2/runner/entrypoint-brain.sh"
+const ENTRYPOINT_PATH = path.resolve(import.meta.dirname, "../../runner/entrypoint-brain.sh")
 
 describe("entrypoint-brain.sh: Hermes config sanity", () => {
   const entrypoint = readFileSync(ENTRYPOINT_PATH, "utf-8")

--- a/tests/unit/mcp-http-server-bin.test.ts
+++ b/tests/unit/mcp-http-server-bin.test.ts
@@ -68,10 +68,7 @@ describe("bin/mcp-http-server: env validation", () => {
 
   it("uses default port 8643 and host 127.0.0.1 when env unset", async () => {
     process.env.GITHUB_TOKEN = "gh-test"
-    await Promise.race([
-      mcpHttpServer(),
-      new Promise((resolve) => setTimeout(resolve, 50)),
-    ])
+    await Promise.race([mcpHttpServer(), new Promise((resolve) => setTimeout(resolve, 50))])
     const opts = buildMcpHttpServer.mock.calls[0]?.[0] as { port: number; host: string }
     expect(opts.port).toBe(8643)
     expect(opts.host).toBe("127.0.0.1")
@@ -81,10 +78,7 @@ describe("bin/mcp-http-server: env validation", () => {
     process.env.GITHUB_TOKEN = "gh-test"
     process.env.KODY_MCP_HTTP_PORT = "9999"
     process.env.KODY_MCP_HTTP_HOST = "0.0.0.0"
-    await Promise.race([
-      mcpHttpServer(),
-      new Promise((resolve) => setTimeout(resolve, 50)),
-    ])
+    await Promise.race([mcpHttpServer(), new Promise((resolve) => setTimeout(resolve, 50))])
     const opts = buildMcpHttpServer.mock.calls[0]?.[0] as { port: number; host: string }
     expect(opts.port).toBe(9999)
     expect(opts.host).toBe("0.0.0.0")
@@ -93,20 +87,14 @@ describe("bin/mcp-http-server: env validation", () => {
   it("forwards apiKey from getApiKey when set", async () => {
     process.env.GITHUB_TOKEN = "gh-test"
     getApiKeyMock.mockReturnValue("secret-key")
-    await Promise.race([
-      mcpHttpServer(),
-      new Promise((resolve) => setTimeout(resolve, 50)),
-    ])
+    await Promise.race([mcpHttpServer(), new Promise((resolve) => setTimeout(resolve, 50))])
     const opts = buildMcpHttpServer.mock.calls[0]?.[0] as { apiKey: string }
     expect(opts.apiKey).toBe("secret-key")
   })
 
   it("registers all 4 expected MCP routes (single-tool routes vs. duty palette)", async () => {
     process.env.GITHUB_TOKEN = "gh-test"
-    await Promise.race([
-      mcpHttpServer(),
-      new Promise((resolve) => setTimeout(resolve, 50)),
-    ])
+    await Promise.race([mcpHttpServer(), new Promise((resolve) => setTimeout(resolve, 50))])
     const opts = buildMcpHttpServer.mock.calls[0]?.[0] as {
       routes: Array<{ path: string; name: string; tools: Array<{ name: string }> }>
     }
@@ -130,10 +118,7 @@ describe("bin/mcp-http-server: env validation", () => {
     process.env.GITHUB_TOKEN = "gh-test"
     process.env.GITHUB_REPOSITORY = "owner/repo"
     process.env.OPERATOR_MENTION = "@alice"
-    await Promise.race([
-      mcpHttpServer(),
-      new Promise((resolve) => setTimeout(resolve, 50)),
-    ])
+    await Promise.race([mcpHttpServer(), new Promise((resolve) => setTimeout(resolve, 50))])
     const opts = buildMcpHttpServer.mock.calls[0]?.[0] as {
       routes: Array<{ path: string; tools: Array<{ name: string }> }>
     }

--- a/tests/unit/verifyScript.test.ts
+++ b/tests/unit/verifyScript.test.ts
@@ -21,8 +21,8 @@ vi.mock("../../src/verify.js", () => ({
   summarizeFailure: (...args: unknown[]) => summarizeFailure(...(args as [Parameters<typeof summarizeFailure>[0]])),
 }))
 
-import { verify } from "../../src/scripts/verify.js"
 import type { Context, Profile } from "../../src/executables/types.js"
+import { verify } from "../../src/scripts/verify.js"
 import type { Action } from "../../src/state.js"
 
 const profile = {} as unknown as Profile

--- a/tests/unit/writeIssueStateComment.test.ts
+++ b/tests/unit/writeIssueStateComment.test.ts
@@ -16,10 +16,10 @@ vi.mock("../../src/scripts/issueStateComment.js", () => ({
   updateStateComment: vi.fn(),
 }))
 
-import { createStateComment, updateStateComment } from "../../src/scripts/issueStateComment.js"
-import { writeIssueStateComment } from "../../src/scripts/writeIssueStateComment.js"
 import type { Context, Profile } from "../../src/executables/types.js"
 import type { StateEnvelope } from "../../src/scripts/issueStateComment.js"
+import { createStateComment, updateStateComment } from "../../src/scripts/issueStateComment.js"
+import { writeIssueStateComment } from "../../src/scripts/writeIssueStateComment.js"
 
 const profile = {} as unknown as Profile
 
@@ -49,23 +49,21 @@ describe("writeIssueStateComment: validation gates", () => {
 
   it("throws when `with.marker` is missing", async () => {
     const ctx = makeCtx({ issue: 1 }, { nextIssueState: NEXT })
-    await expect(writeIssueStateComment(ctx, profile, null, {})).rejects.toThrow(
-      /`with\.marker` is required/,
-    )
+    await expect(writeIssueStateComment(ctx, profile, null, {})).rejects.toThrow(/`with\.marker` is required/)
   })
 
   it("throws when the issue arg is not a positive integer", async () => {
     const ctx = makeCtx({ issue: 0 }, { nextIssueState: NEXT })
-    await expect(
-      writeIssueStateComment(ctx, profile, null, { marker: "kody-issue-state" }),
-    ).rejects.toThrow(/must be a positive integer/)
+    await expect(writeIssueStateComment(ctx, profile, null, { marker: "kody-issue-state" })).rejects.toThrow(
+      /must be a positive integer/,
+    )
   })
 
   it("throws when the named issue arg is absent", async () => {
     const ctx = makeCtx({}, { nextIssueState: NEXT })
-    await expect(
-      writeIssueStateComment(ctx, profile, null, { marker: "kody-issue-state" }),
-    ).rejects.toThrow(/must be a positive integer/)
+    await expect(writeIssueStateComment(ctx, profile, null, { marker: "kody-issue-state" })).rejects.toThrow(
+      /must be a positive integer/,
+    )
   })
 
   it("honors a custom `issueArg` (e.g. for `pr` flows)", async () => {
@@ -87,10 +85,7 @@ describe("writeIssueStateComment: parse-error early-exit", () => {
   })
 
   it("sets exit 1 + reason and does not touch the state comment", async () => {
-    const ctx = makeCtx(
-      { issue: 1 },
-      { nextStateParseError: "missing `kody-issue-state` block in agent output" },
-    )
+    const ctx = makeCtx({ issue: 1 }, { nextStateParseError: "missing `kody-issue-state` block in agent output" })
     await writeIssueStateComment(ctx, profile, null, { marker: "kody-issue-state" })
     expect(ctx.output.exitCode).toBe(1)
     expect(ctx.output.reason).toMatch(/next-state parse failed/)
@@ -101,10 +96,7 @@ describe("writeIssueStateComment: parse-error early-exit", () => {
   it("never lowers a pre-existing non-zero exit code", async () => {
     // If a prior postflight (e.g. verify) already set exit=2, the parse-error
     // path must not silently downgrade it back to 1.
-    const ctx = makeCtx(
-      { issue: 1 },
-      { nextStateParseError: "missing `kody-issue-state` block in agent output" },
-    )
+    const ctx = makeCtx({ issue: 1 }, { nextStateParseError: "missing `kody-issue-state` block in agent output" })
     ctx.output.exitCode = 2
     await writeIssueStateComment(ctx, profile, null, { marker: "kody-issue-state" })
     expect(ctx.output.exitCode).toBe(2)
@@ -127,9 +119,9 @@ describe("writeIssueStateComment: write paths", () => {
   it("throws when github.owner/repo is missing", async () => {
     const ctx = makeCtx({ issue: 1 }, { nextIssueState: NEXT })
     ctx.config = { github: { owner: "", repo: "" } } as never
-    await expect(
-      writeIssueStateComment(ctx, profile, null, { marker: "kody-issue-state" }),
-    ).rejects.toThrow(/github\.owner\/repo must be set/)
+    await expect(writeIssueStateComment(ctx, profile, null, { marker: "kody-issue-state" })).rejects.toThrow(
+      /github\.owner\/repo must be set/,
+    )
   })
 
   it("creates a new state comment when none is loaded", async () => {

--- a/tests/unit/writeJobStateFile.test.ts
+++ b/tests/unit/writeJobStateFile.test.ts
@@ -84,7 +84,9 @@ describe("writeJobStateFile: parse-error path", () => {
     })
     await writeJobStateFile(ctx, PROFILE, null, { jobsDir: ".kody/duties" })
 
-    const after = JSON.parse(fs.readFileSync(path.join(tmp, ".kody", "duties", `${slug}.state.json`), "utf-8")) as StateEnvelope
+    const after = JSON.parse(
+      fs.readFileSync(path.join(tmp, ".kody", "duties", `${slug}.state.json`), "utf-8"),
+    ) as StateEnvelope
     // rev was bumped so the next tick sees a fresh state.
     expect(after.rev).toBe(4)
     // cursor + ledger carry forward — the duty is still at step-2 next time.


### PR DESCRIPTION
## Summary

- CI was failing on `pnpm lint` (Biome check) with 6 format/import-order errors across 5 test files, unrelated to the PR's own path-resolution changes.
- Ran `pnpm lint:fix` (`biome check --write`) to auto-collapse multi-line `Promise.race([...])` calls and reorder `type`-prefixed imports before value imports in `tests/unit/brain-proxy-bin.test.ts`, `mcp-http-server-bin.test.ts`, `verifyScript.test.ts`, `writeIssueStateComment.test.ts`, and `writeJobStateFile.test.ts`.
- `pnpm lint` now reports 0 errors (23 pre-existing `any` warnings unchanged); `mcp__kody-verify__verify` returned `ok: true`. PR #42's actual diff is untouched.

## Changes

- `tests/unit/brain-proxy-bin.test.ts`
- `tests/unit/mcp-http-server-bin.test.ts`
- `tests/unit/verifyScript.test.ts`
- `tests/unit/writeIssueStateComment.test.ts`
- `tests/unit/writeJobStateFile.test.ts`

Closes #41

---
_Opened by kody (single-session autonomous run)._ 