### PR TITLE
Let duties split into task jobs

### DIFF
--- a/docs/jobs-model.md
+++ b/docs/jobs-model.md
@@ -86,6 +86,50 @@ humans, but it is not the source of truth for whether the task's required work
 is complete. The rolled-up `core` (phase, status, attempts, last outcome,
 PR/run URLs) is the task's summary state.
 
+## Plan-and-split tasks
+
+A task can explicitly carry a small hidden plan that says "run these
+executables as slices of this one task." The UI does not need to expose the word
+**job**: a dashboard can present this as a duty with multiple executors, then
+write the task data onto the issue:
+
+```md
+<!-- kody:task-jobs:v1
+[
+  { "executable": "db-migration", "reason": "schema slice" },
+  { "executable": "api-worker", "reason": "API slice" },
+  { "executable": "ui-builder", "reason": "UI slice" }
+]
+-->
+```
+
+`task-jobs` reads that block, seeds `TaskState.jobs`, and dispatches one child
+job per executable. Each child still has exactly one executable. After a child
+succeeds, the engine returns to `task-jobs` in-process and dispatches the next
+unfinished child. When all planned jobs are succeeded, the task state renders
+`Jobs: N/N complete` and the recent history shows the slices that ran.
+
+Failure is intentionally conservative: a failed child stops the current
+workflow run. A manual rerun retries the first non-succeeded planned job before
+moving to later pending jobs, so failed work is not skipped.
+
+### Decisions and rejected alternatives
+
+- **Engine splits, executables do not.** An executable remains a leaf expert and
+  receives an already-scoped slice. Rejected: putting split logic in the
+  executable, because that turns the expert into a coordinator.
+- **Duty triggers, task state carries the plan.** A duty or dashboard may create
+  the issue and hidden task data, but the duty does not wait on children.
+  Rejected: adding waits/state to the duty loop, because duties are cron
+  triggers.
+- **No separate job storage.** The planned jobs live in the task state comment on
+  the issue, beside the task summary and run history. Rejected:
+  `.kody/jobs/`, because that splits one task's source of truth across two
+  locations.
+- **No new orchestration layer.** `task-jobs` is a small script-only executable
+  on top of the existing `runJob` / `runExecutableChain` path. Rejected: a new
+  orchestrator primitive or an "orchestrate" executable kind.
+
 ## The goal = a task list
 
 A goal (`.kody/goals/`, driven by `goal-scheduler` / `goal-tick`) is a list of
@@ -118,12 +162,17 @@ All structural items are implemented:
    engine internals (`src/servers/` + hardcoded CLI verbs), out of the registry.
 9. ✅ **Goal** — the orchestration container: a list of tasks + state, a job per
    task (`goal-scheduler` / `goal-tick` / `.kody/goals/`).
+10. ✅ **Plan-and-split task execution** — `task-jobs` reads hidden issue task
+    data, runs one child job per executable, waits in-process, summarizes the
+    task, and retries failed children before later pending ones.
 
 ## Decided
 
 - **A re-run is a new run, not a new job.** Retries append attempts under the
   same durable job when `jobKey` is stable.
 - **Failure halts the goal** (related tasks; failures are not isolated).
+- **Failure halts a split task run.** Rerun retries the failed planned job
+  before dispatching later slices.
 
 ## Still open (future work)
 

--- a/docs/jobs-model.md
+++ b/docs/jobs-model.md
@@ -103,6 +103,25 @@ write the task data onto the issue:
 -->
 ```
 
+For scheduled duties, the authoring surface is even simpler: the duty file can
+declare the executable list directly:
+
+```md
+---
+every: 1h
+staff: kody
+executables: db-migration, api-worker, ui-builder
+---
+
+# Duty
+
+Keep this feature moving across the database, API, and UI slices.
+```
+
+When that duty is due, `duty-scheduler` creates one GitHub issue with the hidden
+task data above, records the issue number in the duty state, and runs
+`task-jobs` against that issue.
+
 `task-jobs` reads that block, seeds `TaskState.jobs`, and dispatches one child
 job per executable. Each child still has exactly one executable. After a child
 succeeds, the engine returns to `task-jobs` in-process and dispatches the next
@@ -118,9 +137,9 @@ moving to later pending jobs, so failed work is not skipped.
 - **Engine splits, executables do not.** An executable remains a leaf expert and
   receives an already-scoped slice. Rejected: putting split logic in the
   executable, because that turns the expert into a coordinator.
-- **Duty triggers, task state carries the plan.** A duty or dashboard may create
-  the issue and hidden task data, but the duty does not wait on children.
-  Rejected: adding waits/state to the duty loop, because duties are cron
+- **Duty declares, engine splits.** A duty may carry `executables: a, b, c`;
+  `duty-scheduler` creates the task issue and `task-jobs` waits on the children.
+  Rejected: making the duty itself poll child state, because duties are cron
   triggers.
 - **No separate job storage.** The planned jobs live in the task state comment on
   the issue, beside the task summary and run history. Rejected:
@@ -153,8 +172,8 @@ All structural items are implemented:
 4. ✅ **`@kody` mints an instant job** — the comment/manual route mints via
    `mintInstantJob` and runs through `runJob`. Persona (`kody`) and inline `why`
    are both consumed.
-5. ✅ **Cron mints a scheduled job** — `dispatchJobFileTicks` mints one per due
-   duty (`chain:false`), carrying its cadence.
+5. ✅ **Cron mints a scheduled job** — `dispatchDutyFileTicks` mints one per due
+   duty, carrying its cadence.
 6. ✅ **Job points to one executable (0–1)** + safe dispatch. The agent-driven
    `dutyMcp` palette is a separate, intentional safety mechanism, left intact.
 7. ✅ **One runner** — comment, manual, and cron paths all run through `runJob`.
@@ -165,6 +184,9 @@ All structural items are implemented:
 10. ✅ **Plan-and-split task execution** — `task-jobs` reads hidden issue task
     data, runs one child job per executable, waits in-process, summarizes the
     task, and retries failed children before later pending ones.
+11. ✅ **Duty-level multi-executable execution** — a due duty with
+    `executables:` creates one task issue, records that issue on duty state, and
+    runs `task-jobs` for the listed executables.
 
 ## Decided
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kody-ade/kody-engine",
-  "version": "0.4.213",
+  "version": "0.4.214",
   "description": "kody — autonomous development engine. Single-session Claude Code agent behind a generic executor + declarative executable profiles.",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kody-ade/kody-engine",
-  "version": "0.4.212",
+  "version": "0.4.213",
   "description": "kody — autonomous development engine. Single-session Claude Code agent behind a generic executor + declarative executable profiles.",
   "license": "MIT",
   "type": "module",

--- a/src/executables/duty-scheduler/profile.json
+++ b/src/executables/duty-scheduler/profile.json
@@ -4,7 +4,15 @@
   "describe": "Scheduled: for every duty file under .kody/duties/, invoke duty-tick once. No agent on the scheduler itself.",
   "kind": "scheduled",
   "schedule": "*/5 * * * *",
-  "inputs": [],
+  "inputs": [
+    {
+      "name": "duty",
+      "flag": "--duty",
+      "type": "string",
+      "required": false,
+      "describe": "Optional duty slug to run instead of scanning every due duty."
+    }
+  ],
   "claudeCode": {
     "model": "inherit",
     "permissionMode": "default",

--- a/src/executables/task-job-fail-once/profile.json
+++ b/src/executables/task-job-fail-once/profile.json
@@ -1,0 +1,44 @@
+{
+  "name": "task-job-fail-once",
+  "role": "utility",
+  "describe": "Live-test executable that fails the first planned job attempt and succeeds on rerun.",
+  "kind": "oneshot",
+  "inputs": [
+    {
+      "name": "issue",
+      "flag": "--issue",
+      "type": "int",
+      "required": true,
+      "describe": "GitHub issue number that owns the task state."
+    }
+  ],
+  "claudeCode": {
+    "model": "inherit",
+    "permissionMode": "default",
+    "maxTurns": 0,
+    "maxThinkingTokens": null,
+    "systemPromptAppend": null,
+    "tools": [],
+    "hooks": [],
+    "skills": [],
+    "commands": [],
+    "subagents": [],
+    "plugins": [],
+    "mcpServers": []
+  },
+  "cliTools": [],
+  "inputArtifacts": [],
+  "outputArtifacts": [],
+  "scripts": {
+    "preflight": [
+      { "script": "loadIssueContext" },
+      { "script": "loadTaskState" },
+      { "script": "skipAgent" }
+    ],
+    "postflight": [
+      { "script": "failOnceTaskJob" },
+      { "script": "recordOutcome" },
+      { "script": "saveTaskState" }
+    ]
+  }
+}

--- a/src/executables/task-job-fail-once/prompt.md
+++ b/src/executables/task-job-fail-once/prompt.md
@@ -1,0 +1,1 @@
+This executable is script-only.

--- a/src/executables/task-job-pass-a/profile.json
+++ b/src/executables/task-job-pass-a/profile.json
@@ -1,0 +1,43 @@
+{
+  "name": "task-job-pass-a",
+  "role": "utility",
+  "describe": "Live-test executable that deterministically succeeds as planned task slice A.",
+  "kind": "oneshot",
+  "inputs": [
+    {
+      "name": "issue",
+      "flag": "--issue",
+      "type": "int",
+      "required": true,
+      "describe": "GitHub issue number that owns the task state."
+    }
+  ],
+  "claudeCode": {
+    "model": "inherit",
+    "permissionMode": "default",
+    "maxTurns": 0,
+    "maxThinkingTokens": null,
+    "systemPromptAppend": null,
+    "tools": [],
+    "hooks": [],
+    "skills": [],
+    "commands": [],
+    "subagents": [],
+    "plugins": [],
+    "mcpServers": []
+  },
+  "cliTools": [],
+  "inputArtifacts": [],
+  "outputArtifacts": [],
+  "scripts": {
+    "preflight": [
+      { "script": "loadIssueContext" },
+      { "script": "loadTaskState" },
+      { "script": "skipAgent" }
+    ],
+    "postflight": [
+      { "script": "recordOutcome" },
+      { "script": "saveTaskState" }
+    ]
+  }
+}

--- a/src/executables/task-job-pass-a/prompt.md
+++ b/src/executables/task-job-pass-a/prompt.md
@@ -1,0 +1,1 @@
+This executable is script-only.

--- a/src/executables/task-job-pass-b/profile.json
+++ b/src/executables/task-job-pass-b/profile.json
@@ -1,0 +1,43 @@
+{
+  "name": "task-job-pass-b",
+  "role": "utility",
+  "describe": "Live-test executable that deterministically succeeds as planned task slice B.",
+  "kind": "oneshot",
+  "inputs": [
+    {
+      "name": "issue",
+      "flag": "--issue",
+      "type": "int",
+      "required": true,
+      "describe": "GitHub issue number that owns the task state."
+    }
+  ],
+  "claudeCode": {
+    "model": "inherit",
+    "permissionMode": "default",
+    "maxTurns": 0,
+    "maxThinkingTokens": null,
+    "systemPromptAppend": null,
+    "tools": [],
+    "hooks": [],
+    "skills": [],
+    "commands": [],
+    "subagents": [],
+    "plugins": [],
+    "mcpServers": []
+  },
+  "cliTools": [],
+  "inputArtifacts": [],
+  "outputArtifacts": [],
+  "scripts": {
+    "preflight": [
+      { "script": "loadIssueContext" },
+      { "script": "loadTaskState" },
+      { "script": "skipAgent" }
+    ],
+    "postflight": [
+      { "script": "recordOutcome" },
+      { "script": "saveTaskState" }
+    ]
+  }
+}

--- a/src/executables/task-job-pass-b/prompt.md
+++ b/src/executables/task-job-pass-b/prompt.md
@@ -1,0 +1,1 @@
+This executable is script-only.

--- a/src/executables/task-jobs/profile.json
+++ b/src/executables/task-jobs/profile.json
@@ -1,0 +1,41 @@
+{
+  "name": "task-jobs",
+  "role": "utility",
+  "describe": "Runs the next pending executable from a hidden task job plan on an issue.",
+  "inputs": [
+    {
+      "name": "issue",
+      "flag": "--issue",
+      "type": "int",
+      "required": true,
+      "describe": "GitHub issue number that carries the task job plan."
+    }
+  ],
+  "claudeCode": {
+    "model": "inherit",
+    "permissionMode": "default",
+    "maxTurns": 0,
+    "maxThinkingTokens": null,
+    "systemPromptAppend": null,
+    "tools": [],
+    "hooks": [],
+    "skills": [],
+    "commands": [],
+    "subagents": [],
+    "plugins": [],
+    "mcpServers": []
+  },
+  "cliTools": [],
+  "inputArtifacts": [],
+  "outputArtifacts": [],
+  "scripts": {
+    "preflight": [
+      { "script": "loadIssueContext" },
+      { "script": "loadTaskState" },
+      { "script": "planTaskJobs" },
+      { "script": "dispatchNextTaskJob" },
+      { "script": "skipAgent" }
+    ],
+    "postflight": []
+  }
+}

--- a/src/executables/task-jobs/prompt.md
+++ b/src/executables/task-jobs/prompt.md
@@ -1,0 +1,1 @@
+This executable is script-only.

--- a/src/executables/types.ts
+++ b/src/executables/types.ts
@@ -411,6 +411,10 @@ export interface Context {
      * a GitHub App (bot author), stalling the pipeline at classify.
      */
     nextDispatch?: { executable: string; cliArgs: Record<string, unknown> }
+    /** In-process hand-off to a full Job, preserving job identity in task state. */
+    nextJob?: Job
+    /** Where to return after nextJob succeeds. Used by task-jobs to keep draining pending work. */
+    afterNextJob?: { executable: string; cliArgs: Record<string, unknown> }
   }
   /**
    * If a preflight script sets this to true, the executor skips the agent

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -17,7 +17,7 @@ import { loadConfig, parseProviderModel } from "./config.js"
 import { runContainerLoop } from "./container.js"
 import { DISCIPLINE } from "./discipline.js"
 import { emitEvent } from "./events.js"
-import type { Context, InputSpec, Profile, ScriptEntry } from "./executables/types.js"
+import type { Context, InputSpec, Job, Profile, ScriptEntry } from "./executables/types.js"
 import { KODY_NAMESPACE, removeLabel } from "./lifecycleLabels.js"
 import { startLitellmIfNeeded } from "./litellm.js"
 import { loadProfile, validateScriptReferences } from "./profile.js"
@@ -180,6 +180,12 @@ export interface ExecutorOutput {
    * the follow-up run silently ignored it, stalling the pipeline at classify.
    */
   nextDispatch?: { executable: string; cliArgs: Record<string, unknown> }
+  /** In-process hand-off to a full Job, preserving job identity in task state. */
+  nextJob?: Job
+  /** Where to return after nextJob succeeds. */
+  afterNextJob?: { executable: string; cliArgs: Record<string, unknown> }
+  /** Internal state snapshot for in-process continuations. */
+  taskState?: TaskState
 }
 
 export async function runExecutable(profileName: string, input: ExecutorInput): Promise<ExecutorOutput> {
@@ -629,6 +635,9 @@ export async function runExecutable(profileName: string, input: ExecutorInput): 
       prUrl: ctx.output.prUrl,
       reason: ctx.output.reason,
       nextDispatch: ctx.output.nextDispatch,
+      nextJob: ctx.output.nextJob,
+      afterNextJob: ctx.output.afterNextJob,
+      taskState: ctx.data.taskState as TaskState | undefined,
     })
   } finally {
     // Clear any kody:* lifecycle labels stamped by `setLifecycleLabel`
@@ -676,15 +685,65 @@ export const MAX_CHAIN_HOPS = 60
  */
 export async function runExecutableChain(profileName: string, input: ExecutorInput): Promise<ExecutorOutput> {
   let result = await runExecutable(profileName, input)
-  for (let hops = 1; result.nextDispatch && hops <= MAX_CHAIN_HOPS; hops++) {
-    const next = result.nextDispatch
-    process.stdout.write(`→ kody: in-process hand-off → ${next.executable} (hop ${hops}/${MAX_CHAIN_HOPS})\n\n`)
-    result = await runExecutable(next.executable, { ...input, cliArgs: next.cliArgs })
+  let chainData: Record<string, unknown> = {
+    ...(input.preloadedData ?? {}),
+    ...(result.taskState ? { taskState: result.taskState } : {}),
   }
-  if (result.nextDispatch) {
-    process.stderr.write(
-      `[kody] in-process hand-off cap (${MAX_CHAIN_HOPS}) reached; not running ${result.nextDispatch.executable}\n`,
-    )
+  for (let hops = 1; (result.nextDispatch || result.nextJob) && hops <= MAX_CHAIN_HOPS; hops++) {
+    if (result.nextJob) {
+      const next = result.nextJob
+      const after = result.afterNextJob
+      const label = next.executable ?? next.duty ?? "unknown"
+      process.stdout.write(`→ kody: in-process job hand-off → ${label} (hop ${hops}/${MAX_CHAIN_HOPS})\n\n`)
+      const { runJob } = await import("./job.js")
+      const childResult = await runJob(next, {
+        cwd: input.cwd,
+        config: input.config,
+        verbose: input.verbose,
+        quiet: input.quiet,
+        preloadedData: chainData,
+      })
+      if (
+        after &&
+        childResult.exitCode === 0 &&
+        !childResult.nextDispatch &&
+        !childResult.nextJob &&
+        !childResult.afterNextJob
+      ) {
+        chainData = {
+          ...chainData,
+          ...(childResult.taskState ? { taskState: childResult.taskState } : {}),
+        }
+        process.stdout.write(`→ kody: in-process return → ${after.executable} (hop ${hops}/${MAX_CHAIN_HOPS})\n\n`)
+        result = await runExecutable(after.executable, {
+          ...input,
+          cliArgs: after.cliArgs,
+          preloadedData: chainData,
+        })
+        chainData = {
+          ...chainData,
+          ...(result.taskState ? { taskState: result.taskState } : {}),
+        }
+      } else {
+        result = childResult
+        chainData = {
+          ...chainData,
+          ...(result.taskState ? { taskState: result.taskState } : {}),
+        }
+      }
+      continue
+    }
+    const next = result.nextDispatch!
+    process.stdout.write(`→ kody: in-process hand-off → ${next.executable} (hop ${hops}/${MAX_CHAIN_HOPS})\n\n`)
+    result = await runExecutable(next.executable, { ...input, cliArgs: next.cliArgs, preloadedData: chainData })
+    chainData = {
+      ...chainData,
+      ...(result.taskState ? { taskState: result.taskState } : {}),
+    }
+  }
+  if (result.nextDispatch || result.nextJob) {
+    const pending = result.nextDispatch?.executable ?? result.nextJob?.executable ?? result.nextJob?.duty ?? "unknown"
+    process.stderr.write(`[kody] in-process hand-off cap (${MAX_CHAIN_HOPS}) reached; not running ${pending}\n`)
   }
   return result
 }

--- a/src/job.ts
+++ b/src/job.ts
@@ -16,37 +16,25 @@ import type { Job, JobFlavor } from "./executables/types.js"
 import type { ExecutorInput, ExecutorOutput } from "./executor.js"
 import { runExecutable, runExecutableChain } from "./executor.js"
 
+export { stableJobKey } from "./jobIdentity.js"
+
+import { stableJobKey } from "./jobIdentity.js"
+
 /** Default staff persona for instant `@kody` jobs (the agreed starting point). */
 export const DEFAULT_INSTANT_PERSONA = "kody"
 let localJobSeq = 0
 
 /**
  * Stable id for one run attempt, recorded under the task job. In GitHub Actions
- * the workflow run (id + attempt) is the natural attempt id. Off-CI, fall back
- * to a flavor + timestamp stamp plus a counter.
+ * the workflow run (id + attempt) is the natural attempt id; a local sequence
+ * keeps multiple in-process child jobs distinct inside the same workflow run.
+ * Off-CI, fall back to a flavor + timestamp stamp plus the same counter.
  */
 export function newJobId(flavor: JobFlavor): string {
-  const runId = process.env.GITHUB_RUN_ID
-  if (runId) return `gh-${runId}-${process.env.GITHUB_RUN_ATTEMPT ?? "1"}`
   localJobSeq += 1
+  const runId = process.env.GITHUB_RUN_ID
+  if (runId) return `gh-${runId}-${process.env.GITHUB_RUN_ATTEMPT ?? "1"}-${localJobSeq}`
   return `${flavor}-${Date.now()}-${localJobSeq}`
-}
-
-/** Stable key for the required work on a task; retries keep this value. */
-export function stableJobKey(job: Job): string {
-  const executable = job.executable ?? job.duty ?? "unknown"
-  if (job.flavor === "scheduled" && job.duty) return `scheduled:${job.duty}:${executable}`
-  const target = typeof job.target === "number" ? job.target : targetFromCliArgs(job.cliArgs)
-  return target === undefined ? `${job.flavor}:${executable}` : `${job.flavor}:${executable}:${target}`
-}
-
-function targetFromCliArgs(cliArgs: Record<string, unknown> | undefined): number | undefined {
-  if (!cliArgs) return undefined
-  for (const key of ["issue", "pr", "target", "issue_number"]) {
-    const value = cliArgs[key]
-    if (typeof value === "number" && Number.isFinite(value)) return value
-  }
-  return undefined
 }
 
 /** Thrown when a minted Job fails boundary validation. */
@@ -96,6 +84,7 @@ export interface RunJobBase {
   config?: KodyConfig
   verbose?: boolean
   quiet?: boolean
+  preloadedData?: Record<string, unknown>
   /**
    * Follow in-process stage hand-offs (`runExecutableChain`) — the default,
    * matching the comment/manual route. Set `false` for the cron tick path,
@@ -130,7 +119,7 @@ export async function runJob(job: Job, base: RunJobBase): Promise<ExecutorOutput
     throw new InvalidJobError("job resolves to no executable or duty")
   }
 
-  const preloadedData: Record<string, unknown> = {}
+  const preloadedData: Record<string, unknown> = { ...(base.preloadedData ?? {}) }
   // Stamp both identities: jobKey is stable required work on the task; jobId is
   // this execution attempt.
   preloadedData.jobId = newJobId(valid.flavor)

--- a/src/jobIdentity.ts
+++ b/src/jobIdentity.ts
@@ -1,0 +1,18 @@
+import type { Job } from "./executables/types.js"
+
+/** Stable key for the required work on a task; retries keep this value. */
+export function stableJobKey(job: Job): string {
+  const executable = job.executable ?? job.duty ?? "unknown"
+  if (job.flavor === "scheduled" && job.duty) return `scheduled:${job.duty}:${executable}`
+  const target = typeof job.target === "number" ? job.target : targetFromCliArgs(job.cliArgs)
+  return target === undefined ? `${job.flavor}:${executable}` : `${job.flavor}:${executable}:${target}`
+}
+
+export function targetFromCliArgs(cliArgs: Record<string, unknown> | undefined): number | undefined {
+  if (!cliArgs) return undefined
+  for (const key of ["issue", "pr", "target", "issue_number"]) {
+    const value = cliArgs[key]
+    if (typeof value === "number" && Number.isFinite(value)) return value
+  }
+  return undefined
+}

--- a/src/scripts/dispatchDutyFileTicks.ts
+++ b/src/scripts/dispatchDutyFileTicks.ts
@@ -22,10 +22,12 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
 import type { PreflightScript } from "../executables/types.js"
+import { gh } from "../issue.js"
 import { mintScheduledJob, runJob } from "../job.js"
 import { loadProfile } from "../profile.js"
-import { type ScheduleEvery, scheduleEveryToMs, splitFrontmatter } from "./jobFrontmatter.js"
+import { type JobFrontmatter, type ScheduleEvery, scheduleEveryToMs, splitFrontmatter } from "./jobFrontmatter.js"
 import { resolveBackend } from "./jobState/index.js"
+import { TASK_JOBS_MARKER } from "./planTaskJobs.js"
 
 export const dispatchDutyFileTicks: PreflightScript = async (ctx, _profile, args) => {
   ctx.skipAgent = true
@@ -47,15 +49,22 @@ export const dispatchDutyFileTicks: PreflightScript = async (ctx, _profile, args
   }
 
   try {
-    const slugs = listJobSlugs(path.join(ctx.cwd, jobsDir))
-    ctx.data.jobSlugCount = slugs.length
+    const onlyDuty = parseDutyFilter(ctx.args.duty)
+    const jobsPath = path.join(ctx.cwd, jobsDir)
+    const slugs = filterSlugs(listJobSlugs(jobsPath), onlyDuty)
+    const folderSlugList = filterSlugs(listFolderDutySlugs(jobsPath), onlyDuty)
+    ctx.data.jobSlugCount = slugs.length + folderSlugList.length
 
-    if (slugs.length === 0) {
-      process.stdout.write(`[jobs] no job files in ${jobsDir}\n`)
+    if (slugs.length === 0 && folderSlugList.length === 0) {
+      const filter = onlyDuty ? ` matching ${onlyDuty}` : ""
+      process.stdout.write(`[jobs] no job files${filter} in ${jobsDir}\n`)
       return
     }
 
-    process.stdout.write(`[jobs] ticking ${slugs.length} job(s) via ${targetExecutable}\n`)
+    const filtered = onlyDuty ? ` matching ${onlyDuty}` : ""
+    process.stdout.write(
+      `[jobs] ticking ${slugs.length + folderSlugList.length} job(s)${filtered} via ${targetExecutable}\n`,
+    )
 
     const results: Array<{
       slug: string
@@ -80,7 +89,6 @@ export const dispatchDutyFileTicks: PreflightScript = async (ctx, _profile, args
     // folder (`.kody/duties/<slug>/`); if a stale `.kody/duties/<slug>.md`
     // still exists for the same slug, the folder wins and the .md tick is
     // skipped below — otherwise the slug would fire twice in one wake.
-    const folderSlugList = listFolderDutySlugs(path.join(ctx.cwd, jobsDir))
     const folderDutySlugs = new Set(folderSlugList)
     const scheduledDuties = folderSlugList
       .map((slug): ScheduledDuty | null => {
@@ -142,7 +150,8 @@ export const dispatchDutyFileTicks: PreflightScript = async (ctx, _profile, args
       // cadence guard (`every:`) and the routing rule (`tickScript:`)
       // consume it. A previous version parsed the file twice; folded
       // here to keep the dispatcher cheap on repos with many jobs.
-      const frontmatter = readJobFrontmatter(ctx.cwd, jobsDir, slug)
+      const dutyFile = readJobFile(ctx.cwd, jobsDir, slug)
+      const frontmatter = dutyFile.frontmatter
 
       // Hard kill-switch — when the dashboard's enable/disable toggle
       // flips a job off, the frontmatter carries `disabled: true`. Skip
@@ -174,6 +183,38 @@ export const dispatchDutyFileTicks: PreflightScript = async (ctx, _profile, args
       if (decision.skip) {
         process.stdout.write(`[jobs] ⏭  skip ${slug}: ${decision.reason}\n`)
         results.push({ slug, exitCode: 0, skipped: true, reason: decision.reason })
+        continue
+      }
+
+      if (frontmatter.executables && frontmatter.executables.length > 0) {
+        try {
+          const task = createDutyTaskIssue({
+            slug,
+            body: dutyFile.body,
+            frontmatter,
+            cwd: ctx.cwd,
+          })
+          await stampFired(backend, slug, now, task)
+          process.stdout.write(`[jobs] → run ${slug} multi-executable task #${task.number} (task-jobs)\n`)
+          const out = await runJob(
+            mintScheduledJob({
+              duty: slug,
+              executable: "task-jobs",
+              schedule: frontmatter.every,
+              persona: frontmatter.staff,
+              cliArgs: { issue: task.number },
+            }),
+            { cwd: ctx.cwd, config: ctx.config, verbose: ctx.verbose, quiet: ctx.quiet },
+          )
+          results.push({ slug, exitCode: out.exitCode, reason: out.reason })
+          if (out.exitCode !== 0) {
+            process.stderr.write(`[jobs] task ${slug} failed (exit ${out.exitCode}): ${out.reason ?? ""}\n`)
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err)
+          process.stderr.write(`[jobs] task ${slug} crashed: ${msg}\n`)
+          results.push({ slug, exitCode: 99, reason: msg })
+        }
         continue
       }
 
@@ -298,17 +339,67 @@ function formatAgo(ms: number): string {
  * callers can apply their own defaults (cadence falls through to "fire",
  * routing falls back to the LLM-driven target).
  */
-function readJobFrontmatter(
-  cwd: string,
-  jobsDir: string,
-  slug: string,
-): ReturnType<typeof splitFrontmatter>["frontmatter"] {
+function readJobFile(cwd: string, jobsDir: string, slug: string): { frontmatter: JobFrontmatter; body: string } {
   try {
     const raw = fs.readFileSync(path.join(cwd, jobsDir, `${slug}.md`), "utf-8")
-    return splitFrontmatter(raw).frontmatter
+    return splitFrontmatter(raw)
   } catch {
-    return {}
+    return { frontmatter: {}, body: "" }
   }
+}
+
+function parseDutyFilter(raw: unknown): string | undefined {
+  return typeof raw === "string" && raw.trim().length > 0 ? raw.trim() : undefined
+}
+
+function filterSlugs(slugs: string[], onlyDuty: string | undefined): string[] {
+  return onlyDuty ? slugs.filter((slug) => slug === onlyDuty) : slugs
+}
+
+interface DutyTaskIssue {
+  number: number
+  url: string
+}
+
+function createDutyTaskIssue(opts: {
+  slug: string
+  body: string
+  frontmatter: JobFrontmatter
+  cwd: string
+}): DutyTaskIssue {
+  const title = `Duty ${opts.slug} - multi-executable task`
+  const body = buildDutyTaskIssueBody(opts.slug, opts.body, opts.frontmatter)
+  const out = gh(["issue", "create", "--title", title, "--body-file", "-"], { input: body, cwd: opts.cwd })
+  const url =
+    out
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .pop() ?? ""
+  const match = url.match(/\/issues\/(\d+)\b/)
+  if (!match) throw new Error(`gh issue create returned unexpected output: ${out}`)
+  return { number: Number(match[1]), url }
+}
+
+function buildDutyTaskIssueBody(slug: string, dutyBody: string, frontmatter: JobFrontmatter): string {
+  const specs = (frontmatter.executables ?? []).map((executable) => ({
+    executable,
+    duty: slug,
+    ...(frontmatter.staff ? { staff: frontmatter.staff } : {}),
+    reason: `Duty \`${slug}\` slice for \`${executable}\`.`,
+    flavor: "scheduled",
+    ...(frontmatter.every ? { schedule: frontmatter.every } : {}),
+  }))
+  return [
+    `# Duty task: ${slug}`,
+    "",
+    dutyBody.trim() || "(no duty body)",
+    "",
+    `<!-- ${TASK_JOBS_MARKER}`,
+    JSON.stringify(specs, null, 2),
+    "-->",
+    "",
+  ].join("\n")
 }
 
 function listJobSlugs(absDir: string): string[] {
@@ -343,10 +434,19 @@ function listFolderDutySlugs(absDir: string): string[] {
 }
 
 /** Persist `lastFiredAt = now` for a scheduled folder-duty (no duty-tick to do it). */
-async function stampFired(backend: ReturnType<typeof resolveBackend>, slug: string, now: number): Promise<void> {
+async function stampFired(
+  backend: ReturnType<typeof resolveBackend>,
+  slug: string,
+  now: number,
+  task?: DutyTaskIssue,
+): Promise<void> {
   try {
     const loaded = await backend.load(slug)
-    const nextData = { ...(loaded.state.data ?? {}), lastFiredAt: new Date(now).toISOString() }
+    const nextData = {
+      ...(loaded.state.data ?? {}),
+      lastFiredAt: new Date(now).toISOString(),
+      ...(task ? { lastTaskIssue: task.number, lastTaskUrl: task.url } : {}),
+    }
     await backend.save(loaded, { ...loaded.state, data: nextData })
   } catch (err) {
     process.stderr.write(`[jobs] failed to stamp lastFiredAt for ${slug}: ${String(err)}\n`)

--- a/src/scripts/dispatchNextTaskJob.ts
+++ b/src/scripts/dispatchNextTaskJob.ts
@@ -1,0 +1,49 @@
+import type { Job, PreflightScript } from "../executables/types.js"
+import { stableJobKey } from "../jobIdentity.js"
+import { emptyState, nextPendingTaskJob, type TaskJob, type TaskState } from "../state.js"
+
+export const dispatchNextTaskJob: PreflightScript = async (ctx, profile) => {
+  const state = (ctx.data.taskState as TaskState | undefined) ?? emptyState()
+  const ids = Array.isArray(ctx.data.plannedTaskJobIds)
+    ? (ctx.data.plannedTaskJobIds as unknown[]).filter((id): id is string => typeof id === "string")
+    : undefined
+  const next = nextPendingTaskJob(state, ids)
+  ctx.skipAgent = true
+
+  if (!next) {
+    ctx.output.exitCode = 0
+    ctx.output.reason = "all planned task jobs are complete"
+    return
+  }
+
+  const plannedJobs = Array.isArray(ctx.data.plannedTaskJobs)
+    ? (ctx.data.plannedTaskJobs as unknown[]).filter(isJob)
+    : []
+  ctx.output.nextJob = plannedJobs.find((job) => stableJobKey(job) === next.id) ?? taskJobToJob(next, ctx.args.issue)
+  if (typeof ctx.args.issue === "number") {
+    ctx.output.afterNextJob = { executable: profile.name, cliArgs: { issue: ctx.args.issue } }
+  }
+}
+
+function taskJobToJob(job: TaskJob, issueArg: unknown): Job {
+  const target = typeof job.target === "number" ? job.target : typeof issueArg === "number" ? issueArg : undefined
+  return {
+    executable: job.executable,
+    ...(job.duty ? { duty: job.duty } : {}),
+    ...(job.reason ? { why: job.reason } : {}),
+    ...(job.staff ? { persona: job.staff } : {}),
+    ...(job.schedule ? { schedule: job.schedule } : {}),
+    ...(typeof target === "number" ? { target, cliArgs: { issue: target } } : { cliArgs: {} }),
+    flavor: job.flavor ?? "instant",
+  }
+}
+
+function isJob(input: unknown): input is Job {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return false
+  const job = input as Partial<Job>
+  return (
+    typeof job.executable === "string" &&
+    (job.flavor === "instant" || job.flavor === "scheduled") &&
+    (!job.cliArgs || (typeof job.cliArgs === "object" && !Array.isArray(job.cliArgs)))
+  )
+}

--- a/src/scripts/failOnceTaskJob.ts
+++ b/src/scripts/failOnceTaskJob.ts
@@ -1,0 +1,27 @@
+import type { Job, PostflightScript } from "../executables/types.js"
+import { stableJobKey } from "../jobIdentity.js"
+import type { TaskState } from "../state.js"
+
+export const failOnceTaskJob: PostflightScript = async (ctx, profile) => {
+  ctx.skipAgent = true
+
+  const issue = typeof ctx.args.issue === "number" ? ctx.args.issue : undefined
+  const fallbackJob: Job = {
+    executable: profile.name,
+    flavor: "instant",
+    ...(typeof issue === "number" ? { target: issue, cliArgs: { issue } } : { cliArgs: {} }),
+  }
+  const jobKey = typeof ctx.data.jobKey === "string" ? ctx.data.jobKey : stableJobKey(fallbackJob)
+  const state = ctx.data.taskState as TaskState | undefined
+  const runs = state?.jobs?.[jobKey]?.runs ?? []
+  const hasFailedBefore = runs.some((run) => run.status === "failed")
+
+  if (!hasFailedBefore) {
+    ctx.output.exitCode = 1
+    ctx.output.reason = "intentional first-attempt failure for task job live test"
+    return
+  }
+
+  ctx.output.exitCode = 0
+  ctx.output.reason = "task job live test succeeded after prior failure"
+}

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -24,7 +24,9 @@ import { dispatchClassified } from "./dispatchClassified.js"
 import { dispatchDutyFileTicks } from "./dispatchDutyFileTicks.js"
 import { dispatchDutyTicks } from "./dispatchDutyTicks.js"
 import { dispatchNextTask } from "./dispatchNextTask.js"
+import { dispatchNextTaskJob } from "./dispatchNextTaskJob.js"
 import { ensurePr } from "./ensurePr.js"
+import { failOnceTaskJob } from "./failOnceTaskJob.js"
 import { finalizeGoal } from "./finalizeGoal.js"
 import { finalizeTerminal } from "./finalizeTerminal.js"
 import { finishFlow } from "./finishFlow.js"
@@ -58,6 +60,7 @@ import { parseJobStateFromAgentResult } from "./parseJobStateFromAgentResult.js"
 import { parseReproOutput } from "./parseReproOutput.js"
 import { persistArtifacts } from "./persistArtifacts.js"
 import { persistFlowState } from "./persistFlowState.js"
+import { planTaskJobs } from "./planTaskJobs.js"
 import { postAgentComment } from "./postAgentComment.js"
 import { postIssueComment } from "./postIssueComment.js"
 import { postPlanComment } from "./postPlanComment.js"
@@ -133,6 +136,8 @@ export const preflightScripts: Record<string, PreflightScript> = {
   warmupMcp,
   dispatchDutyTicks,
   dispatchDutyFileTicks,
+  planTaskJobs,
+  dispatchNextTaskJob,
   runTickScript,
   runPreviewBuild,
   loadGoalState,
@@ -181,6 +186,7 @@ export const postflightScripts: Record<string, PostflightScript> = {
   notifyTerminal,
   openQaIssue,
   createQaGoal,
+  failOnceTaskJob,
   recordOutcome,
   mergeReleasePr,
   waitForCi,

--- a/src/scripts/jobFrontmatter.ts
+++ b/src/scripts/jobFrontmatter.ts
@@ -4,8 +4,9 @@
  * Duty markdown at `.kody/duties/<slug>.md` may begin with a `---\n…\n---\n`
  * block carrying flat scalar key/value pairs (no nesting, no flow style).
  * Recognized fields are `every:` (cadence), `disabled:`, `tickScript:`, and
- * `staff:` (the executor persona). The parser silently ignores unknown keys
- * so the dashboard and engine can evolve the frontmatter independently.
+ * `staff:` (the executor persona), and `executables:` (multi-part duty
+ * slices). The parser silently ignores unknown keys so the dashboard and
+ * engine can evolve the frontmatter independently.
  *
  * Mirror of the dashboard's ticked-frontmatter parser in Kody-Dashboard —
  * keep the two in sync if the format grows.
@@ -91,6 +92,15 @@ export interface JobFrontmatter {
    * See `src/dutyMcp.ts` for the registered tool palette.
    */
   tools?: string[]
+  /**
+   * Multi-executable duty mode. When present, the scheduler creates one task
+   * issue and runs `task-jobs` instead of ticking the duty once. Each listed
+   * executable becomes one child job on that task.
+   *
+   * Authored as a comma-separated list on one line:
+   *   `executables: db-worker, api-worker, ui-worker`
+   */
+  executables?: string[]
 }
 
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/
@@ -175,6 +185,12 @@ function parseFlatYaml(text: string): JobFrontmatter {
         .map((s) => s.trim())
         .filter(Boolean)
       if (names.length > 0) out.tools = names
+    } else if (key === "executables") {
+      const names = value
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+      if (names.length > 0) out.executables = names
     }
   }
   return out

--- a/src/scripts/planTaskJobs.ts
+++ b/src/scripts/planTaskJobs.ts
@@ -13,6 +13,7 @@ export const TASK_JOBS_MARKER = "kody:task-jobs:v1"
 
 export interface TaskJobSpec {
   executable: string
+  duty?: string
   reason?: string
   staff?: string
   persona?: string
@@ -41,6 +42,7 @@ export function taskJobSpecToJob(spec: TaskJobSpec, issueNumber: number): Job {
   const cliArgs = spec.cliArgs ?? { issue: issueNumber }
   const target = typeof spec.target === "number" ? spec.target : (targetFromCliArgs(cliArgs) ?? issueNumber)
   return {
+    duty: spec.duty,
     executable: spec.executable,
     why: spec.reason,
     persona: spec.persona ?? spec.staff,
@@ -103,6 +105,7 @@ function normalizeSpec(input: unknown, index: number): TaskJobSpec {
   }
   return {
     executable,
+    ...(typeof raw.duty === "string" && raw.duty.trim() ? { duty: raw.duty.trim() } : {}),
     ...(typeof raw.reason === "string" && raw.reason.trim() ? { reason: raw.reason.trim() } : {}),
     ...(typeof raw.staff === "string" && raw.staff.trim() ? { staff: raw.staff.trim() } : {}),
     ...(typeof raw.persona === "string" && raw.persona.trim() ? { persona: raw.persona.trim() } : {}),

--- a/src/scripts/planTaskJobs.ts
+++ b/src/scripts/planTaskJobs.ts
@@ -1,0 +1,135 @@
+import type { Job, JobFlavor, PreflightScript } from "../executables/types.js"
+import { stableJobKey, targetFromCliArgs } from "../jobIdentity.js"
+import {
+  emptyState,
+  type PlannedTaskJob,
+  type TaskState,
+  type TaskTarget,
+  upsertTaskJobs,
+  writeTaskState,
+} from "../state.js"
+
+export const TASK_JOBS_MARKER = "kody:task-jobs:v1"
+
+export interface TaskJobSpec {
+  executable: string
+  reason?: string
+  staff?: string
+  persona?: string
+  cliArgs?: Record<string, unknown>
+  target?: number
+  flavor?: JobFlavor
+  schedule?: string
+}
+
+export function parseTaskJobSpecs(body: string): TaskJobSpec[] {
+  const match = body.match(new RegExp(`<!--\\s*${TASK_JOBS_MARKER}\\s*([\\s\\S]*?)-->`))
+  if (!match) return []
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(match[1]!.trim())
+  } catch (err) {
+    throw new Error(`task job plan is not valid JSON: ${err instanceof Error ? err.message : String(err)}`)
+  }
+  if (!Array.isArray(parsed)) throw new Error("task job plan must be a JSON array")
+
+  return parsed.map((entry, index) => normalizeSpec(entry, index))
+}
+
+export function taskJobSpecToJob(spec: TaskJobSpec, issueNumber: number): Job {
+  const cliArgs = spec.cliArgs ?? { issue: issueNumber }
+  const target = typeof spec.target === "number" ? spec.target : (targetFromCliArgs(cliArgs) ?? issueNumber)
+  return {
+    executable: spec.executable,
+    why: spec.reason,
+    persona: spec.persona ?? spec.staff,
+    schedule: spec.schedule,
+    target,
+    cliArgs,
+    flavor: spec.flavor ?? "instant",
+  }
+}
+
+export const planTaskJobs: PreflightScript = async (ctx) => {
+  const issueNumber = ctx.args.issue as number | undefined
+  if (!issueNumber) {
+    ctx.skipAgent = true
+    ctx.output.exitCode = 64
+    ctx.output.reason = "planTaskJobs requires --issue"
+    return
+  }
+
+  const issue = ctx.data.issue as { body?: string } | undefined
+  const specs = parseTaskJobSpecs(issue?.body ?? "")
+  if (specs.length === 0) {
+    ctx.skipAgent = true
+    ctx.output.exitCode = 64
+    ctx.output.reason = `no ${TASK_JOBS_MARKER} block found on issue #${issueNumber}`
+    return
+  }
+
+  const jobs = specs.map((spec) => taskJobSpecToJob(spec, issueNumber))
+  const planned = jobs.map(jobToPlannedTaskJob)
+  assertUniqueJobIds(planned)
+
+  const prior = (ctx.data.taskState as TaskState | undefined) ?? emptyState()
+  const next = upsertTaskJobs(prior, planned, new Date().toISOString())
+  ctx.data.taskState = next
+  ctx.data.plannedTaskJobs = jobs
+  ctx.data.plannedTaskJobIds = planned.map((job) => job.id)
+
+  const target = ctx.data.commentTargetType as TaskTarget | undefined
+  const number = ctx.data.commentTargetNumber as number | undefined
+  if (target && number) writeTaskState(target, number, next, ctx.cwd)
+}
+
+function normalizeSpec(input: unknown, index: number): TaskJobSpec {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error(`task job plan entry ${index} must be an object`)
+  }
+  const raw = input as Record<string, unknown>
+  const executable = typeof raw.executable === "string" ? raw.executable.trim() : ""
+  if (!/^[a-z][a-z0-9-]*$/.test(executable)) {
+    throw new Error(`task job plan entry ${index} must have a valid executable`)
+  }
+  const cliArgs = raw.cliArgs
+  if (cliArgs !== undefined && (!cliArgs || typeof cliArgs !== "object" || Array.isArray(cliArgs))) {
+    throw new Error(`task job plan entry ${index} cliArgs must be an object`)
+  }
+  const flavor = raw.flavor
+  if (flavor !== undefined && flavor !== "instant" && flavor !== "scheduled") {
+    throw new Error(`task job plan entry ${index} flavor must be "instant" or "scheduled"`)
+  }
+  return {
+    executable,
+    ...(typeof raw.reason === "string" && raw.reason.trim() ? { reason: raw.reason.trim() } : {}),
+    ...(typeof raw.staff === "string" && raw.staff.trim() ? { staff: raw.staff.trim() } : {}),
+    ...(typeof raw.persona === "string" && raw.persona.trim() ? { persona: raw.persona.trim() } : {}),
+    ...(cliArgs ? { cliArgs: cliArgs as Record<string, unknown> } : {}),
+    ...(typeof raw.target === "number" && Number.isFinite(raw.target) ? { target: raw.target } : {}),
+    ...(flavor === "instant" || flavor === "scheduled" ? { flavor } : {}),
+    ...(typeof raw.schedule === "string" && raw.schedule.trim() ? { schedule: raw.schedule.trim() } : {}),
+  }
+}
+
+function jobToPlannedTaskJob(job: Job): PlannedTaskJob {
+  return {
+    id: stableJobKey(job),
+    executable: job.executable ?? job.duty ?? "unknown",
+    ...(job.duty ? { duty: job.duty } : {}),
+    ...(job.persona ? { staff: job.persona } : {}),
+    ...(job.flavor ? { flavor: job.flavor } : {}),
+    ...(job.schedule ? { schedule: job.schedule } : {}),
+    ...(typeof job.target === "number" ? { target: job.target } : {}),
+    ...(job.why ? { reason: job.why } : {}),
+  }
+}
+
+function assertUniqueJobIds(planned: PlannedTaskJob[]): void {
+  const seen = new Set<string>()
+  for (const job of planned) {
+    if (seen.has(job.id)) throw new Error(`duplicate planned task job id: ${job.id}`)
+    seen.add(job.id)
+  }
+}

--- a/src/scripts/saveTaskState.ts
+++ b/src/scripts/saveTaskState.ts
@@ -54,6 +54,7 @@ export const saveTaskState: PostflightScript = async (ctx, profile) => {
   if (typeof ctx.data.runUrl === "string") next.core.runUrl = ctx.data.runUrl as string
 
   writeTaskState(target, number, next, ctx.cwd)
+  ctx.data.taskState = next
   ctx.data.taskStateRendered = renderStateComment(next)
 }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -52,6 +52,17 @@ export interface TaskJob {
   runs: TaskJobRun[]
 }
 
+export interface PlannedTaskJob {
+  id: string
+  executable: string
+  duty?: string
+  staff?: string
+  flavor?: JobFlavor
+  schedule?: string
+  target?: number
+  reason?: string
+}
+
 export interface Action {
   type: string
   payload: Record<string, unknown>
@@ -361,6 +372,46 @@ export function reduce(
     history: newHistory,
     flow: state.flow,
   }
+}
+
+export function upsertTaskJobs(state: TaskState, planned: PlannedTaskJob[], timestamp: string): TaskState {
+  if (planned.length === 0) return state
+  const jobs: Record<string, TaskJob> = { ...(state.jobs ?? {}) }
+  for (const plan of planned) {
+    const prior = jobs[plan.id]
+    jobs[plan.id] = {
+      id: plan.id,
+      executable: plan.executable,
+      ...((plan.duty ?? prior?.duty) ? { duty: plan.duty ?? prior?.duty } : {}),
+      ...((plan.staff ?? prior?.staff) ? { staff: plan.staff ?? prior?.staff } : {}),
+      ...((plan.flavor ?? prior?.flavor) ? { flavor: plan.flavor ?? prior?.flavor } : {}),
+      ...((plan.schedule ?? prior?.schedule) ? { schedule: plan.schedule ?? prior?.schedule } : {}),
+      ...(typeof plan.target === "number"
+        ? { target: plan.target }
+        : prior?.target !== undefined
+          ? { target: prior.target }
+          : {}),
+      ...((plan.reason ?? prior?.reason) ? { reason: plan.reason ?? prior?.reason } : {}),
+      status: prior?.status ?? "pending",
+      createdAt: prior?.createdAt ?? timestamp,
+      updatedAt: prior?.updatedAt ?? timestamp,
+      ...(prior?.completedAt ? { completedAt: prior.completedAt } : {}),
+      ...(prior?.runUrl ? { runUrl: prior.runUrl } : {}),
+      ...(prior?.prUrl ? { prUrl: prior.prUrl } : {}),
+      runs: prior?.runs ?? [],
+    }
+  }
+  return { ...state, jobs }
+}
+
+export function nextPendingTaskJob(state: TaskState, ids?: string[]): TaskJob | null {
+  const jobs = state.jobs ?? {}
+  const keys = ids && ids.length > 0 ? ids : Object.keys(jobs)
+  for (const key of keys) {
+    const job = jobs[key]
+    if (job && job.status !== "succeeded") return job
+  }
+  return null
 }
 
 function reduceJobs(

--- a/tests/unit/dispatchDutyFileTicks.multiExecutables.test.ts
+++ b/tests/unit/dispatchDutyFileTicks.multiExecutables.test.ts
@@ -1,0 +1,126 @@
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { KodyConfig } from "../../src/config.js"
+import type { Context, Profile } from "../../src/executables/types.js"
+import { parseTaskJobSpecs } from "../../src/scripts/planTaskJobs.js"
+
+const ghMock = vi.hoisted(() => vi.fn())
+const runJobMock = vi.hoisted(() => vi.fn())
+
+vi.mock("../../src/issue.js", async () => {
+  const actual = await vi.importActual<typeof import("../../src/issue.js")>("../../src/issue.js")
+  return { ...actual, gh: ghMock }
+})
+
+vi.mock("../../src/job.js", async () => {
+  const actual = await vi.importActual<typeof import("../../src/job.js")>("../../src/job.js")
+  return { ...actual, runJob: runJobMock }
+})
+
+import { dispatchDutyFileTicks } from "../../src/scripts/dispatchDutyFileTicks.js"
+
+let tmp: string
+
+beforeEach(() => {
+  ghMock.mockReset()
+  ghMock.mockReturnValue("https://github.com/o/r/issues/777")
+  runJobMock.mockReset()
+  runJobMock.mockResolvedValue({ exitCode: 0 })
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dispatch-duty-multi-"))
+  fs.mkdirSync(path.join(tmp, ".kody", "duties"), { recursive: true })
+})
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true })
+  vi.clearAllMocks()
+})
+
+function writeDuty(slug: string, frontmatter: string, body = "# Duty\n\nDo the work."): void {
+  fs.writeFileSync(path.join(tmp, ".kody", "duties", `${slug}.md`), `---\n${frontmatter}\n---\n${body}`)
+}
+
+function ctxFor(): Context {
+  const config: KodyConfig = {
+    quality: { typecheck: "", lint: "", format: "", testUnit: "" },
+    git: { defaultBranch: "main" },
+    github: { owner: "o", repo: "r" },
+    agent: { model: "anthropic/test" },
+    jobs: { stateBackend: "local-file" },
+  }
+  return {
+    args: {},
+    cwd: tmp,
+    config,
+    data: {},
+    output: { exitCode: 0 },
+  }
+}
+
+const PROFILE = {} as unknown as Profile
+
+describe("dispatchDutyFileTicks multi-executable duties", () => {
+  it("creates a task issue and runs task-jobs for a duty with executables", async () => {
+    writeDuty("daily-check", "every: 1h\nstaff: kody\nexecutables: plan-verify, probe-skill")
+
+    const ctx = ctxFor()
+    await dispatchDutyFileTicks(ctx, PROFILE, {
+      jobsDir: ".kody/duties",
+      targetExecutable: "duty-tick",
+      slugArg: "duty",
+    })
+
+    expect(ghMock).toHaveBeenCalledTimes(1)
+    const [args, options] = ghMock.mock.calls[0]!
+    expect(args).toEqual(["issue", "create", "--title", "Duty daily-check - multi-executable task", "--body-file", "-"])
+    expect(options.cwd).toBe(tmp)
+
+    const specs = parseTaskJobSpecs(options.input)
+    expect(specs).toEqual([
+      {
+        executable: "plan-verify",
+        duty: "daily-check",
+        staff: "kody",
+        reason: "Duty `daily-check` slice for `plan-verify`.",
+        flavor: "scheduled",
+        schedule: "1h",
+      },
+      {
+        executable: "probe-skill",
+        duty: "daily-check",
+        staff: "kody",
+        reason: "Duty `daily-check` slice for `probe-skill`.",
+        flavor: "scheduled",
+        schedule: "1h",
+      },
+    ])
+
+    expect(runJobMock).toHaveBeenCalledTimes(1)
+    expect(runJobMock.mock.calls[0]![0]).toMatchObject({
+      duty: "daily-check",
+      executable: "task-jobs",
+      persona: "kody",
+      schedule: "1h",
+      cliArgs: { issue: 777 },
+      flavor: "scheduled",
+    })
+    expect(runJobMock.mock.calls[0]![1]).toMatchObject({ cwd: tmp })
+    expect(runJobMock.mock.calls[0]![1].chain).not.toBe(false)
+  })
+
+  it("records the created task issue on the duty state file", async () => {
+    writeDuty("daily-check", "every: 1h\nstaff: kody\nexecutables: plan-verify")
+
+    await dispatchDutyFileTicks(ctxFor(), PROFILE, {
+      jobsDir: ".kody/duties",
+      targetExecutable: "duty-tick",
+      slugArg: "duty",
+    })
+
+    const state = JSON.parse(fs.readFileSync(path.join(tmp, ".kody", "duties", "daily-check.state.json"), "utf-8"))
+    expect(state.data.lastTaskIssue).toBe(777)
+    expect(state.data.lastTaskUrl).toBe("https://github.com/o/r/issues/777")
+    expect(typeof state.data.lastFiredAt).toBe("string")
+  })
+})

--- a/tests/unit/dispatchDutyFileTicks.routing.test.ts
+++ b/tests/unit/dispatchDutyFileTicks.routing.test.ts
@@ -121,6 +121,23 @@ describe("dispatchDutyFileTicks routing", () => {
     expect(targets).toContain("duty-tick")
   })
 
+  it("can target one duty slug without ticking the other due duties", async () => {
+    writeJob("scripted-duty", "tickScript: .kody/scripts/x.sh\nstaff: kody")
+    writeJob("agent-duty", "every: 1h\nstaff: kody")
+
+    const ctx = ctxFor()
+    ctx.args = { duty: "agent-duty" }
+    await dispatchDutyFileTicks(ctx, PROFILE, {
+      jobsDir: ".kody/duties",
+      targetExecutable: "duty-tick",
+      slugArg: "duty",
+    })
+
+    expect(runExecutableMock).toHaveBeenCalledTimes(1)
+    expect(runExecutableMock.mock.calls[0]![0]).toBe("duty-tick")
+    expect(runExecutableMock.mock.calls[0]![1].cliArgs).toEqual({ duty: "agent-duty" })
+  })
+
   it("deduplicates a slug present as both a folder-duty and a .md (folder wins, no double-fire)", async () => {
     // Folder-duty: scheduled, fires one-shot as itself.
     const folder = path.join(tmp, ".kody", "duties", "hybrid")

--- a/tests/unit/executor-nextJob.test.ts
+++ b/tests/unit/executor-nextJob.test.ts
@@ -1,0 +1,165 @@
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import type { KodyConfig } from "../../src/config.js"
+import { runExecutableChain } from "../../src/executor.js"
+import { emptyState, upsertTaskJobs } from "../../src/state.js"
+
+const config: KodyConfig = {
+  quality: { typecheck: "", lint: "", testUnit: "", format: "" },
+  git: { defaultBranch: "main" },
+  github: { owner: "o", repo: "r" },
+  agent: { model: "claude/claude-haiku-4-5-20251001" },
+}
+
+function writeProfile(root: string, name: string, preflight: unknown[], postflight: unknown[] = []): void {
+  const dir = path.join(root, ".kody", "executables", name)
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(
+    path.join(dir, "profile.json"),
+    JSON.stringify(
+      {
+        name,
+        role: "utility",
+        describe: "",
+        inputs: [{ name: "issue", flag: "--issue", type: "int", required: true, describe: "" }],
+        claudeCode: {
+          model: "inherit",
+          permissionMode: "default",
+          maxTurns: 0,
+          maxThinkingTokens: null,
+          systemPromptAppend: null,
+          tools: [],
+          hooks: [],
+          skills: [],
+          commands: [],
+          subagents: [],
+          plugins: [],
+          mcpServers: [],
+        },
+        cliTools: [],
+        scripts: { preflight, postflight },
+      },
+      null,
+      2,
+    ),
+  )
+  fs.writeFileSync(path.join(dir, "prompt.md"), "")
+}
+
+describe("executor: nextJob chain", () => {
+  let tmp = ""
+  const originalCwd = process.cwd()
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    if (tmp) fs.rmSync(tmp, { recursive: true, force: true })
+    tmp = ""
+  })
+
+  it("returns to the parent after a planned child succeeds", async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "kody-next-job-"))
+    process.chdir(tmp)
+    writeProfile(tmp, "parent", [{ script: "dispatchNextTaskJob" }, { script: "skipAgent" }])
+    writeProfile(tmp, "child", [{ script: "skipAgent" }], [{ script: "saveTaskState" }])
+
+    const plannedJob = {
+      executable: "child",
+      cliArgs: { issue: 42 },
+      target: 42,
+      flavor: "instant" as const,
+      why: "child slice",
+    }
+    const taskState = upsertTaskJobs(
+      emptyState(),
+      [{ id: "instant:child:42", executable: "child", flavor: "instant", target: 42, reason: "child slice" }],
+      "2026-06-08T08:00:00Z",
+    )
+
+    const result = await runExecutableChain("parent", {
+      cliArgs: { issue: 42 },
+      cwd: tmp,
+      config,
+      preloadedData: {
+        taskState,
+        plannedTaskJobs: [plannedJob],
+        plannedTaskJobIds: ["instant:child:42"],
+        commentTargetType: "issue",
+        commentTargetNumber: 42,
+      },
+    })
+
+    expect(result.exitCode).toBe(0)
+    expect(result.reason).toBe("all planned task jobs are complete")
+    expect(result.nextJob).toBeUndefined()
+    expect(result.taskState?.jobs["instant:child:42"]?.status).toBe("succeeded")
+  })
+
+  it("retries a failed planned child on rerun before moving to later children", async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "kody-next-job-rerun-"))
+    process.chdir(tmp)
+    writeProfile(tmp, "parent", [{ script: "dispatchNextTaskJob" }, { script: "skipAgent" }])
+    writeProfile(
+      tmp,
+      "failer",
+      [{ script: "skipAgent" }],
+      [{ script: "failOnceTaskJob" }, { script: "recordOutcome" }, { script: "saveTaskState" }],
+    )
+    writeProfile(tmp, "child", [{ script: "skipAgent" }], [{ script: "recordOutcome" }, { script: "saveTaskState" }])
+
+    const failerJob = {
+      executable: "failer",
+      cliArgs: { issue: 42 },
+      target: 42,
+      flavor: "instant" as const,
+      why: "first slice",
+    }
+    const childJob = {
+      executable: "child",
+      cliArgs: { issue: 42 },
+      target: 42,
+      flavor: "instant" as const,
+      why: "second slice",
+    }
+    const ids = ["instant:failer:42", "instant:child:42"]
+    const taskState = upsertTaskJobs(
+      emptyState(),
+      [
+        { id: "instant:failer:42", executable: "failer", flavor: "instant", target: 42, reason: "first slice" },
+        { id: "instant:child:42", executable: "child", flavor: "instant", target: 42, reason: "second slice" },
+      ],
+      "2026-06-08T08:00:00Z",
+    )
+    const baseData = {
+      plannedTaskJobs: [failerJob, childJob],
+      plannedTaskJobIds: ids,
+      commentTargetType: "issue",
+      commentTargetNumber: 42,
+    }
+
+    const first = await runExecutableChain("parent", {
+      cliArgs: { issue: 42 },
+      cwd: tmp,
+      config,
+      preloadedData: { ...baseData, taskState },
+    })
+
+    expect(first.exitCode).toBe(1)
+    expect(first.taskState?.jobs["instant:failer:42"]?.status).toBe("failed")
+    expect(first.taskState?.jobs["instant:child:42"]?.status).toBe("pending")
+
+    const second = await runExecutableChain("parent", {
+      cliArgs: { issue: 42 },
+      cwd: tmp,
+      config,
+      preloadedData: { ...baseData, taskState: first.taskState },
+    })
+
+    expect(second.exitCode).toBe(0)
+    expect(second.reason).toBe("all planned task jobs are complete")
+    expect(second.taskState?.jobs["instant:failer:42"]?.status).toBe("succeeded")
+    expect(second.taskState?.jobs["instant:failer:42"]?.runs.map((run) => run.status)).toEqual(["failed", "succeeded"])
+    expect(second.taskState?.jobs["instant:child:42"]?.status).toBe("succeeded")
+  })
+})

--- a/tests/unit/failOnceTaskJob.test.ts
+++ b/tests/unit/failOnceTaskJob.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest"
+import type { Context, Profile } from "../../src/executables/types.js"
+import { failOnceTaskJob } from "../../src/scripts/failOnceTaskJob.js"
+import { emptyState, reduce, upsertTaskJobs } from "../../src/state.js"
+
+function makeCtx(taskState = emptyState()): Context {
+  return {
+    args: { issue: 42 },
+    cwd: "/repo",
+    config: {},
+    data: {
+      taskState,
+      jobKey: "instant:task-job-fail-once:42",
+    },
+    output: { exitCode: 0 },
+  } as unknown as Context
+}
+
+describe("failOnceTaskJob", () => {
+  const profile = { name: "task-job-fail-once" } as Profile
+
+  it("fails the first attempt for its planned job", async () => {
+    const planned = upsertTaskJobs(
+      emptyState(),
+      [{ id: "instant:task-job-fail-once:42", executable: "task-job-fail-once", flavor: "instant", target: 42 }],
+      "2026-06-08T08:00:00Z",
+    )
+    const ctx = makeCtx(planned)
+
+    await failOnceTaskJob(ctx, profile, null)
+
+    expect(ctx.skipAgent).toBe(true)
+    expect(ctx.output.exitCode).toBe(1)
+    expect(ctx.output.reason).toMatch(/intentional first-attempt failure/)
+  })
+
+  it("succeeds after a failed run already exists", async () => {
+    let state = upsertTaskJobs(
+      emptyState(),
+      [{ id: "instant:task-job-fail-once:42", executable: "task-job-fail-once", flavor: "instant", target: 42 }],
+      "2026-06-08T08:00:00Z",
+    )
+    state = reduce(
+      state,
+      "task-job-fail-once",
+      {
+        type: "TASK_JOB_FAIL_ONCE_FAILED",
+        payload: { reason: "intentional first-attempt failure" },
+        timestamp: "2026-06-08T08:01:00Z",
+      },
+      "idle",
+      null,
+      { jobKey: "instant:task-job-fail-once:42", jobId: "gh-1", flavor: "instant", target: 42 },
+    )
+    const ctx = makeCtx(state)
+
+    await failOnceTaskJob(ctx, profile, null)
+
+    expect(ctx.skipAgent).toBe(true)
+    expect(ctx.output.exitCode).toBe(0)
+    expect(ctx.output.reason).toMatch(/succeeded after prior failure/)
+  })
+})

--- a/tests/unit/job.test.ts
+++ b/tests/unit/job.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 // Hoist-safe mock of the executor so runJob is tested in isolation (no real
 // executable spins up). Mirrors tests/unit/dispatchDutyFileTicks.routing.test.ts.
@@ -10,6 +10,7 @@ import {
   InvalidJobError,
   mintInstantJob,
   mintScheduledJob,
+  newJobId,
   runJob,
   validateJob,
 } from "../../src/job.js"
@@ -18,6 +19,10 @@ describe("runJob (Phase 1 seam)", () => {
   beforeEach(() => {
     runExecutableChain.mockReset()
     runExecutableChain.mockResolvedValue({ exitCode: 0 })
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
   })
 
   it("lowers an instant job onto runExecutableChain with its executable + cliArgs", async () => {
@@ -61,6 +66,18 @@ describe("runJob (Phase 1 seam)", () => {
     expect(first?.jobKey).toBe("instant:run:42")
     expect(second?.jobKey).toBe("instant:run:42")
     expect(first?.jobId).not.toBe(second?.jobId)
+  })
+
+  it("keeps GitHub attempt ids unique when multiple jobs run in one workflow", () => {
+    vi.stubEnv("GITHUB_RUN_ID", "77")
+    vi.stubEnv("GITHUB_RUN_ATTEMPT", "3")
+
+    const first = newJobId("instant")
+    const second = newJobId("instant")
+
+    expect(first).toMatch(/^gh-77-3-\d+$/)
+    expect(second).toMatch(/^gh-77-3-\d+$/)
+    expect(first).not.toBe(second)
   })
 
   it("carries the DispatchResult's why through mintInstantJob into jobWhy", async () => {

--- a/tests/unit/jobFrontmatter.test.ts
+++ b/tests/unit/jobFrontmatter.test.ts
@@ -80,6 +80,16 @@ describe("splitFrontmatter", () => {
     expect(splitFrontmatter("---\nmentions:\n---\nx").frontmatter.mentions).toBeUndefined()
     expect(splitFrontmatter("---\nmentions: , ,\n---\nx").frontmatter.mentions).toBeUndefined()
   })
+
+  it("parses a comma-separated `executables` list into trimmed executable names", () => {
+    const { frontmatter } = splitFrontmatter("---\nexecutables: plan-verify, probe-skill\n---\nx")
+    expect(frontmatter.executables).toEqual(["plan-verify", "probe-skill"])
+  })
+
+  it("leaves executables unset when the value is blank or all-empty", () => {
+    expect(splitFrontmatter("---\nexecutables:\n---\nx").frontmatter.executables).toBeUndefined()
+    expect(splitFrontmatter("---\nexecutables: , ,\n---\nx").frontmatter.executables).toBeUndefined()
+  })
 })
 
 describe("isScheduleEvery", () => {

--- a/tests/unit/sharedScriptsInvariants.test.ts
+++ b/tests/unit/sharedScriptsInvariants.test.ts
@@ -173,6 +173,21 @@ const KNOWN_SOLO_SCRIPTS: Record<string, SoloEntry> = {
     reason:
       "preview-build is the only executable that builds a deployable preview image (remote builder). Single-purpose; no other executable shares the build step.",
   },
+  planTaskJobs: {
+    owner: "task-jobs",
+    reason:
+      "task-jobs-only task-data planner. Kept in scripts so dashboard-written issue metadata can seed task state before dispatch.",
+  },
+  dispatchNextTaskJob: {
+    owner: "task-jobs",
+    reason:
+      "task-jobs-only handoff step. It selects the next pending planned job and returns a nextJob for the generic runner.",
+  },
+  failOnceTaskJob: {
+    owner: "task-job-fail-once",
+    reason:
+      "live-test-only deterministic failure/retry probe for task-jobs; it proves failed planned slices block and rerun.",
+  },
   fixFlow: { owner: "fix", reason: "fix bootstrap: open PR branch and derive reviewer feedback." },
   requireFeedbackActions: { owner: "fix", reason: "fix-only contract check for FEEDBACK_ACTIONS." },
   fixCiFlow: { owner: "fix-ci", reason: "fix-ci bootstrap: open PR branch and attach failing CI logs." },

--- a/tests/unit/state.test.ts
+++ b/tests/unit/state.test.ts
@@ -3,11 +3,13 @@ import {
   type Action,
   CorruptStateError,
   emptyState,
+  nextPendingTaskJob,
   parseStateComment,
   reduce,
   renderStateComment,
   STATE_BEGIN,
   STATE_END,
+  upsertTaskJobs,
 } from "../../src/state.js"
 
 describe("state: emptyState", () => {
@@ -229,6 +231,97 @@ describe("state: reduce", () => {
   it("is a no-op when action is null", () => {
     const s = emptyState()
     expect(reduce(s, "build", null)).toBe(s)
+  })
+})
+
+describe("state: explicit task jobs", () => {
+  it("seeds planned jobs as pending durable work", () => {
+    const s = upsertTaskJobs(
+      emptyState(),
+      [
+        { id: "instant:plan-verify:42", executable: "plan-verify", flavor: "instant", target: 42, reason: "api" },
+        { id: "instant:probe-skill:42", executable: "probe-skill", flavor: "instant", target: 42, reason: "ui" },
+      ],
+      "2026-06-08T08:00:00Z",
+    )
+
+    expect(Object.keys(s.jobs)).toEqual(["instant:plan-verify:42", "instant:probe-skill:42"])
+    expect(s.jobs["instant:plan-verify:42"]).toMatchObject({
+      executable: "plan-verify",
+      status: "pending",
+      target: 42,
+      reason: "api",
+      runs: [],
+    })
+    expect(renderStateComment(s)).toContain("**Jobs:** 0/2 complete")
+  })
+
+  it("preserves completed runs when the plan is seen again", () => {
+    const planned = { id: "instant:plan-verify:42", executable: "plan-verify", flavor: "instant" as const, target: 42 }
+    let s = upsertTaskJobs(emptyState(), [planned], "2026-06-08T08:00:00Z")
+    s = reduce(
+      s,
+      "plan-verify",
+      { type: "VERIFY_COMPLETED", payload: {}, timestamp: "2026-06-08T08:05:00Z" },
+      "idle",
+      null,
+      {
+        jobKey: "instant:plan-verify:42",
+        jobId: "gh-1-1",
+        flavor: "instant",
+        target: 42,
+      },
+    )
+
+    const replanned = upsertTaskJobs(s, [{ ...planned, reason: "updated plan text" }], "2026-06-08T08:10:00Z")
+
+    expect(replanned.jobs["instant:plan-verify:42"]?.status).toBe("succeeded")
+    expect(replanned.jobs["instant:plan-verify:42"]?.reason).toBe("updated plan text")
+    expect(replanned.jobs["instant:plan-verify:42"]?.runs.map((r) => r.id)).toEqual(["gh-1-1"])
+  })
+
+  it("selects the next pending planned job in plan order", () => {
+    let s = upsertTaskJobs(
+      emptyState(),
+      [
+        { id: "instant:plan-verify:42", executable: "plan-verify", flavor: "instant", target: 42 },
+        { id: "instant:probe-skill:42", executable: "probe-skill", flavor: "instant", target: 42 },
+      ],
+      "2026-06-08T08:00:00Z",
+    )
+    s = reduce(
+      s,
+      "plan-verify",
+      { type: "VERIFY_COMPLETED", payload: {}, timestamp: "2026-06-08T08:05:00Z" },
+      "idle",
+      null,
+      { jobKey: "instant:plan-verify:42", jobId: "gh-1-1", flavor: "instant", target: 42 },
+    )
+
+    const next = nextPendingTaskJob(s, ["instant:plan-verify:42", "instant:probe-skill:42"])
+    expect(next?.id).toBe("instant:probe-skill:42")
+  })
+
+  it("selects a failed planned job before later pending jobs so reruns retry the failed slice", () => {
+    let s = upsertTaskJobs(
+      emptyState(),
+      [
+        { id: "instant:plan-verify:42", executable: "plan-verify", flavor: "instant", target: 42 },
+        { id: "instant:probe-skill:42", executable: "probe-skill", flavor: "instant", target: 42 },
+      ],
+      "2026-06-08T08:00:00Z",
+    )
+    s = reduce(
+      s,
+      "plan-verify",
+      { type: "PLAN_VERIFY_FAILED", payload: { reason: "boom" }, timestamp: "2026-06-08T08:05:00Z" },
+      "idle",
+      null,
+      { jobKey: "instant:plan-verify:42", jobId: "gh-1-1", flavor: "instant", target: 42 },
+    )
+
+    const next = nextPendingTaskJob(s, ["instant:plan-verify:42", "instant:probe-skill:42"])
+    expect(next?.id).toBe("instant:plan-verify:42")
   })
 })
 

--- a/tests/unit/taskJobs.test.ts
+++ b/tests/unit/taskJobs.test.ts
@@ -37,6 +37,32 @@ describe("task job plan parsing", () => {
     expect(stableJobKey(job)).toBe("instant:plan-verify:42")
   })
 
+  it("turns a duty-planned entry into one scheduled child job", () => {
+    const job = taskJobSpecToJob(
+      {
+        executable: "probe-skill",
+        duty: "daily-check",
+        reason: "UI slice",
+        staff: "qa",
+        flavor: "scheduled",
+        schedule: "1h",
+      },
+      42,
+    )
+
+    expect(job).toMatchObject({
+      duty: "daily-check",
+      executable: "probe-skill",
+      cliArgs: { issue: 42 },
+      target: 42,
+      flavor: "scheduled",
+      persona: "qa",
+      schedule: "1h",
+      why: "UI slice",
+    })
+    expect(stableJobKey(job)).toBe("scheduled:daily-check:probe-skill")
+  })
+
   it("keeps explicit cliArgs when the task data needs a non-default target", () => {
     const job = taskJobSpecToJob({ executable: "review", cliArgs: { pr: 77 }, reason: "review slice" }, 42)
 

--- a/tests/unit/taskJobs.test.ts
+++ b/tests/unit/taskJobs.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+import type { Context, Profile } from "../../src/executables/types.js"
+import { stableJobKey } from "../../src/job.js"
+import { dispatchNextTaskJob } from "../../src/scripts/dispatchNextTaskJob.js"
+import { parseTaskJobSpecs, TASK_JOBS_MARKER, taskJobSpecToJob } from "../../src/scripts/planTaskJobs.js"
+import { emptyState, upsertTaskJobs } from "../../src/state.js"
+
+describe("task job plan parsing", () => {
+  it("reads hidden task data from the issue body", () => {
+    const specs = parseTaskJobSpecs(`Do the work.
+
+<!-- ${TASK_JOBS_MARKER}
+[
+  { "executable": "plan-verify", "reason": "api slice" },
+  { "executable": "probe-skill", "staff": "qa", "reason": "ui slice" }
+]
+-->
+`)
+
+    expect(specs).toEqual([
+      { executable: "plan-verify", reason: "api slice" },
+      { executable: "probe-skill", staff: "qa", reason: "ui slice" },
+    ])
+  })
+
+  it("turns each entry into one instant job targeting the parent issue by default", () => {
+    const job = taskJobSpecToJob({ executable: "plan-verify", reason: "api slice", staff: "qa" }, 42)
+
+    expect(job).toMatchObject({
+      executable: "plan-verify",
+      cliArgs: { issue: 42 },
+      target: 42,
+      flavor: "instant",
+      persona: "qa",
+      why: "api slice",
+    })
+    expect(stableJobKey(job)).toBe("instant:plan-verify:42")
+  })
+
+  it("keeps explicit cliArgs when the task data needs a non-default target", () => {
+    const job = taskJobSpecToJob({ executable: "review", cliArgs: { pr: 77 }, reason: "review slice" }, 42)
+
+    expect(job.cliArgs).toEqual({ pr: 77 })
+    expect(job.target).toBe(77)
+    expect(stableJobKey(job)).toBe("instant:review:77")
+  })
+
+  it("rejects malformed task data instead of silently running the wrong thing", () => {
+    expect(() => parseTaskJobSpecs(`<!-- ${TASK_JOBS_MARKER}\n{}\n-->`)).toThrow(/array/)
+    expect(() => parseTaskJobSpecs(`<!-- ${TASK_JOBS_MARKER}\n[{ "reason": "missing executable" }]\n-->`)).toThrow(
+      /executable/,
+    )
+  })
+
+  it("dispatches the next pending job with a task-jobs return address", async () => {
+    const job = taskJobSpecToJob({ executable: "plan-verify", reason: "api slice" }, 42)
+    const id = stableJobKey(job)
+    const taskState = upsertTaskJobs(
+      emptyState(),
+      [{ id, executable: "plan-verify", flavor: "instant", target: 42, reason: "api slice" }],
+      "2026-06-08T08:00:00Z",
+    )
+    const ctx = {
+      args: { issue: 42 },
+      cwd: "/repo",
+      config: {},
+      data: { taskState, plannedTaskJobs: [job], plannedTaskJobIds: [id] },
+      output: { exitCode: 0 },
+    } as unknown as Context
+
+    await dispatchNextTaskJob(ctx, { name: "task-jobs" } as Profile)
+
+    expect(ctx.output.nextJob).toEqual(job)
+    expect(ctx.output.afterNextJob).toEqual({ executable: "task-jobs", cliArgs: { issue: 42 } })
+  })
+})


### PR DESCRIPTION
## Summary
- add `executables:` duty frontmatter and have duty-scheduler create a task issue with one planned job per executable
- preserve duty/staff/schedule provenance through task-jobs state
- add a targeted `--duty` scheduler filter plus deterministic pass executables for live verification

## Tests
- pnpm vitest run tests/unit/jobFrontmatter.test.ts tests/unit/taskJobs.test.ts tests/unit/dispatchDutyFileTicks.multiExecutables.test.ts tests/unit/dispatchDutyFileTicks.routing.test.ts --no-coverage
- pnpm vitest run tests/unit/dispatchDutyFileTicks.routing.test.ts tests/unit/dispatchDutyFileTicks.multiExecutables.test.ts tests/unit/profile.test.ts --no-coverage
- pnpm typecheck
- pnpm lint (passes with existing noExplicitAny warnings)
- pnpm test
- npm publish --tag live --access public: 0.4.214-live.2
- npm publish --tag latest --access public: 0.4.214

## Live Tests
- Kody-Engine-Tester run 27156639168: duty live-duty-multi-04214 created issue #3669 and completed task-job-pass-a + task-job-pass-b
- Kody-Engine-Tester run 27156750650: immediate duty rerun skipped on cadence and created no duplicate issue
- Kody-Engine-Tester run 27156856201: task-jobs rerun on #3669 no-oped because all planned jobs were complete