### PR TITLE
feat(agent): add reasoning effort control (off|low|medium|high)

### DIFF
--- a/kody.config.schema.json
+++ b/kody.config.schema.json
@@ -63,6 +63,11 @@
           "pattern": "^[^/]+/.+$",
           "description": "Base provider/model string, for example minimax/MiniMax-M3 or claude/claude-sonnet-4-6."
         },
+        "reasoningEffort": {
+          "type": "string",
+          "enum": ["off", "low", "medium", "high"],
+          "description": "Default thinking effort for the Claude Agent SDK. Maps to maxThinkingTokens. 'off' (default) skips the thinking block entirely — no reasoning preamble, no extra tokens. 'low'/'medium'/'high' enable extended thinking with budgets 2_048/10_000/32_000. Overridable per-session via the REASONING_EFFORT env var or the dashboard's chat-level thinking dropdown."
+        },
         "perExecutable": {
           "type": "object",
           "description": "Optional provider/model override by executable name.",

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs"
 import * as path from "node:path"
 import { query } from "@anthropic-ai/claude-agent-sdk"
 import { ensureStableClaudeBinary } from "./claudeBinary.js"
-import { getAnthropicApiKeyOrDummy, type ProviderModel } from "./config.js"
+import { getAnthropicApiKeyOrDummy, type ProviderModel, REASONING_BUDGETS, type ReasoningEffort } from "./config.js"
 import { renderEvent, type SdkMessageLike } from "./format.js"
 
 export interface AgentTokenUsage {
@@ -99,6 +99,19 @@ export interface AgentOptions {
   agents?: Record<string, { description: string; prompt: string; tools?: string[]; model?: string }>
   /** Hard cap on agent turns. null/undefined = SDK default (unbounded). */
   maxTurns?: number | null
+  /**
+   * Thinking level. Maps to the SDK's `maxThinkingTokens` (Anthropic
+   * extended thinking). When set, overrides the explicit
+   * `maxThinkingTokens` field if both are provided — this is the
+   * preferred surface. Unset / `"off"` means no thinking block is sent
+   * to the model, which is the cheapest path (no reasoning preamble,
+   * no thinking-token spend).
+   *
+   * Resolution: `runChatTurn` reads from CLI flag → env var → config.
+   * Direct callers of `runAgent` (tests, executables) can set either
+   * field directly; `reasoningEffort` wins when both are set.
+   */
+  reasoningEffort?: ReasoningEffort | null
   /** Extended-thinking token budget. null/undefined = SDK default. */
   maxThinkingTokens?: number | null
   /**
@@ -495,7 +508,23 @@ export async function runAgent(opts: AgentOptions): Promise<AgentResult> {
       if (typeof opts.maxTurns === "number" && opts.maxTurns > 0) {
         queryOptions.maxTurns = opts.maxTurns
       }
-      if (typeof opts.maxThinkingTokens === "number" && opts.maxThinkingTokens > 0) {
+      // `reasoningEffort` is the canonical user-facing surface. When
+      // set, it fully owns the maxThinkingTokens slot — including
+      // `"off"`, which clears the block entirely (cheapest path). The
+      // explicit `maxThinkingTokens` field is the legacy surface for
+      // direct callers (tests, executables) that don't go through
+      // the level vocabulary; it only applies when `reasoningEffort`
+      // is not provided.
+      if (opts.reasoningEffort !== undefined && opts.reasoningEffort !== null) {
+        if (opts.reasoningEffort === "off") {
+          // Explicitly off: do NOT set maxThinkingTokens. Also clear
+          // any value a legacy caller might have left in the option
+          // bag. The SDK sees no thinking block.
+        } else {
+          const budget = REASONING_BUDGETS[opts.reasoningEffort]
+          if (budget) queryOptions.maxThinkingTokens = budget
+        }
+      } else if (typeof opts.maxThinkingTokens === "number" && opts.maxThinkingTokens > 0) {
         queryOptions.maxThinkingTokens = opts.maxThinkingTokens
       }
       if (typeof opts.systemPromptAppend === "string" && opts.systemPromptAppend.length > 0) {

--- a/src/chat-cli.ts
+++ b/src/chat-cli.ts
@@ -23,7 +23,13 @@ import { eventsFilePath, FileSink, HttpSink, makeRunId, TeeSink } from "./chat/e
 import { runChatTurn } from "./chat/loop.js"
 import { runInteractiveMode } from "./chat/modes/interactive.js"
 import { readMeta, seedInitialMessage, sessionFilePath } from "./chat/session.js"
-import { loadConfig, needsLitellmProxy, parseProviderModel } from "./config.js"
+import {
+  loadConfig,
+  needsLitellmProxy,
+  parseProviderModel,
+  parseReasoningEffort,
+  type ReasoningEffort,
+} from "./config.js"
 import { configureGitIdentity, installLitellmIfNeeded, resolveAuthToken, unpackAllSecrets } from "./kody-cli.js"
 import { startLitellmIfNeeded } from "./litellm.js"
 import { pushWithRetry } from "./pushWithRetry.js"
@@ -36,6 +42,7 @@ export interface ChatArgs {
   model?: string
   dashboardUrl?: string
   cwd?: string
+  reasoningEffort?: ReasoningEffort
   verbose?: boolean
   quiet?: boolean
   errors: string[]
@@ -45,10 +52,16 @@ export const CHAT_HELP = `kody chat — dashboard-driven chat session
 
 Usage:
   kody chat [--session <id>] [--message <text>] [--model <provider/model>]
+             [--reasoning-effort <off|low|medium|high>]
              [--dashboard-url <url>] [--cwd <path>] [--verbose|--quiet]
 
-All inputs may also come from env: SESSION_ID, INIT_MESSAGE, MODEL, DASHBOARD_URL.
+All inputs may also come from env: SESSION_ID, INIT_MESSAGE, MODEL, REASONING_EFFORT, DASHBOARD_URL.
 CLI flags take precedence over env. SESSION_ID is required.
+
+Thinking level maps to the Claude Agent SDK's maxThinkingTokens (Anthropic
+extended thinking). Default is unset (no thinking — cheapest). Set via the
+dashboard's chat-level thinking dropdown, the REASONING_EFFORT env var,
+or this flag.
 
 Exit codes:
   0   reply emitted successfully
@@ -63,6 +76,7 @@ export function parseChatArgs(argv: string[], env: NodeJS.ProcessEnv = process.e
     if (arg === "--session") result.sessionId = argv[++i]
     else if (arg === "--message") result.initMessage = argv[++i]
     else if (arg === "--model") result.model = argv[++i]
+    else if (arg === "--reasoning-effort") result.reasoningEffort = parseReasoningEffort(argv[++i]) ?? undefined
     else if (arg === "--dashboard-url") result.dashboardUrl = argv[++i]
     else if (arg === "--cwd") result.cwd = argv[++i]
     else if (arg === "--verbose") result.verbose = true
@@ -77,6 +91,7 @@ export function parseChatArgs(argv: string[], env: NodeJS.ProcessEnv = process.e
   result.initMessage = result.initMessage ?? env.INIT_MESSAGE ?? undefined
   result.model = result.model ?? env.MODEL ?? undefined
   result.dashboardUrl = result.dashboardUrl ?? env.DASHBOARD_URL ?? undefined
+  result.reasoningEffort = result.reasoningEffort ?? parseReasoningEffort(env.REASONING_EFFORT) ?? undefined
 
   // Normalize empty strings (GH Actions passes `""` for unset optional inputs).
   for (const key of ["sessionId", "initMessage", "model", "dashboardUrl"] as const) {
@@ -85,7 +100,7 @@ export function parseChatArgs(argv: string[], env: NodeJS.ProcessEnv = process.e
   }
 
   if (!result.sessionId && !result.errors.includes("__HELP__")) {
-    result.errors.push("--session <id> (or SESSION_ID env) is required")
+    result.errors.push("--session <id> (or SESSION_ID env) is required)")
   }
 
   return result
@@ -169,6 +184,11 @@ export async function runChat(argv: string[]): Promise<number> {
 
   const config = tryLoadConfig(cwd)
   const modelSpec = args.model ?? config?.agent.model ?? DEFAULT_MODEL
+  // Resolve reasoning effort: CLI flag → env → config default → unset.
+  // Unset stays unset (no maxThinkingTokens set on the SDK call — the
+  // cheapest path, no reasoning preamble).
+  const reasoningEffort: ReasoningEffort | undefined =
+    args.reasoningEffort ?? config?.agent.reasoningEffort ?? undefined
   let model: ReturnType<typeof parseProviderModel>
   try {
     model = parseProviderModel(modelSpec)
@@ -230,6 +250,7 @@ export async function runChat(argv: string[]): Promise<number> {
         meta,
         verbose: args.verbose,
         quiet: args.quiet,
+        ...(reasoningEffort ? { reasoningEffort } : {}),
       })
       return result.exitCode
     }
@@ -243,6 +264,7 @@ export async function runChat(argv: string[]): Promise<number> {
       sink,
       verbose: args.verbose,
       quiet: args.quiet,
+      ...(reasoningEffort ? { reasoningEffort } : {}),
     })
     commitChatFiles(cwd, sessionId, args.verbose ?? false)
     return result.exitCode

--- a/src/chat/loop.ts
+++ b/src/chat/loop.ts
@@ -10,7 +10,7 @@ import * as fs from "node:fs"
 import * as path from "node:path"
 import type { AgentResult } from "../agent.js"
 import { runAgent } from "../agent.js"
-import type { ProviderModel } from "../config.js"
+import type { ProviderModel, ReasoningEffort } from "../config.js"
 import { listExecutables } from "../registry.js"
 import { prepareTaskArtifactsDir, taskArtifactsPromptAddendum, verifyTaskArtifacts } from "../task-artifacts.js"
 import { prepareAttachments } from "./attachments.js"
@@ -178,6 +178,12 @@ export interface ChatTurnOptions {
   repoToken?: string
   /** Override for the system prompt (tests). */
   systemPrompt?: string
+  /**
+   * Thinking level. Forwarded to `runAgent` as `reasoningEffort` and
+   * mapped to the SDK's `maxThinkingTokens` (Anthropic extended
+   * thinking). `undefined` / `"off"` = no thinking block, cheapest path.
+   */
+  reasoningEffort?: ReasoningEffort | null
   /** Seam for tests — defaults to real runAgent. */
   invokeAgent?: (prompt: string) => Promise<AgentResult>
 }
@@ -271,6 +277,7 @@ export async function runChatTurn(opts: ChatTurnOptions): Promise<ChatTurnResult
         verbose: opts.verbose,
         quiet: opts.quiet,
         systemPromptAppend: systemPrompt,
+        ...(opts.reasoningEffort ? { reasoningEffort: opts.reasoningEffort } : {}),
         // Let the agent clone + work on OTHER repos mid-conversation (a
         // repo-less Brain serves many). Enabled whenever we know where repos
         // live; grants read access to that root via additionalDirectories.

--- a/src/chat/modes/interactive.ts
+++ b/src/chat/modes/interactive.ts
@@ -17,7 +17,7 @@ import { execFileSync } from "node:child_process"
 import * as fs from "node:fs"
 import * as path from "node:path"
 import type { AgentResult } from "../../agent.js"
-import type { ProviderModel } from "../../config.js"
+import type { ProviderModel, ReasoningEffort } from "../../config.js"
 import { gh } from "../../issue.js"
 import type { EventSink } from "../events.js"
 import { eventsFilePath, makeRunId } from "../events.js"
@@ -46,6 +46,12 @@ export interface InteractiveModeOptions {
   skipGit?: boolean
   /** Test seam — override poll interval (default 30s). */
   pollIntervalMs?: number
+  /**
+   * Thinking level. Forwarded to every `runChatTurn` call inside the
+   * loop so each turn gets the same thinking budget. Unset / `"off"`
+   * means no thinking block — cheapest path.
+   */
+  reasoningEffort?: ReasoningEffort | null
 }
 
 export interface InteractiveModeResult {
@@ -139,6 +145,7 @@ export async function runInteractiveMode(opts: InteractiveModeOptions): Promise<
         verbose: opts.verbose,
         quiet: opts.quiet,
         invokeAgent: opts.invokeAgent,
+        ...(opts.reasoningEffort ? { reasoningEffort: opts.reasoningEffort } : {}),
       })
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,19 @@ export interface KodyConfig {
   agent: {
     model: string
     /**
+     * Thinking effort. Maps to the Claude Agent SDK's `maxThinkingTokens`
+     * (Anthropic extended thinking). When unset, the SDK runs without
+     * thinking — cheaper, faster, no reasoning preamble. A chat session
+     * can override per-session via the `REASONING_EFFORT` env var or
+     * `--reasoning-effort` CLI flag.
+     *
+     *   "agent": { "model": "claude/...", "reasoningEffort": "medium" }
+     *
+     * Budgets: off → not set (no thinking, no extra cost);
+     *          low → 2_048 · medium → 10_000 · high → 32_000 tokens.
+     */
+    reasoningEffort?: ReasoningEffort
+    /**
      * Per-executable model override. Lets consumers route specific stages to
      * cheaper or stronger models without forking the profile:
      *
@@ -143,6 +156,46 @@ export interface ProviderModel {
   model: string
 }
 
+/**
+ * User-facing thinking level. Maps to `maxThinkingTokens` for the Claude
+ * Agent SDK. Unset / `"off"` means "no thinking" — the SDK runs without
+ * the extended-thinking block, no extra tokens, no reasoning preamble.
+ *
+ * Resolution order (engine-side, all layers independent):
+ *   1. `--reasoning-effort` CLI flag (chat mode only — `kody chat …`)
+ *   2. `REASONING_EFFORT` env var (forwarded by the dashboard workflow)
+ *   3. `agent.reasoningEffort` in kody.config.json
+ *   4. unset → no `maxThinkingTokens` set on the SDK call
+ */
+export type ReasoningEffort = "off" | "low" | "medium" | "high"
+
+export const REASONING_EFFORTS: readonly ReasoningEffort[] = ["off", "low", "medium", "high"] as const
+
+/**
+ * Budget mapping. Indices must match REASONING_EFFORTS:
+ *   REASONING_BUDGETS[1] === 2048   (low)
+ *   REASONING_BUDGETS[2] === 10_000 (medium)
+ *   REASONING_BUDGETS[3] === 32_000 (high)
+ * Off is implicit — we don't set maxThinkingTokens at all in that case.
+ */
+export const REASONING_BUDGETS: Record<Exclude<ReasoningEffort, "off">, number> = {
+  low: 2_048,
+  medium: 10_000,
+  high: 32_000,
+}
+
+/**
+ * Parse a string from the env/CLI into a ReasoningEffort. Returns `null`
+ * for unset / unknown — caller should fall through to the next source in
+ * the resolution order. Case-insensitive; trims whitespace.
+ */
+export function parseReasoningEffort(raw: string | null | undefined): ReasoningEffort | null {
+  if (!raw) return null
+  const v = raw.trim().toLowerCase()
+  if (REASONING_EFFORTS.includes(v as ReasoningEffort)) return v as ReasoningEffort
+  return null
+}
+
 export const LITELLM_DEFAULT_PORT = 4000
 export const LITELLM_DEFAULT_URL = `http://localhost:${LITELLM_DEFAULT_PORT}`
 
@@ -206,6 +259,7 @@ export function loadConfig(projectDir: string = process.cwd()): KodyConfig {
     agent: {
       model: String(agent.model),
       ...parsePerExecutable(agent.perExecutable),
+      ...parseAgentReasoningEffort(agent.reasoningEffort),
     },
     issueContext: parseIssueContext(raw.issueContext),
     testRequirements: parseTestRequirements(raw.testRequirements),
@@ -336,6 +390,18 @@ function parsePerExecutable(raw: unknown): { perExecutable?: Record<string, stri
     if (typeof v === "string" && v.length > 0) out[k] = v
   }
   return Object.keys(out).length > 0 ? { perExecutable: out } : {}
+}
+
+/**
+ * Normalize `agent.reasoningEffort` from the raw config. Unknown / empty
+ * values drop to undefined so the engine falls through to the next
+ * resolution source (env var → CLI flag → unset). Forward-compatible:
+ * when a new level is added in the future, older engine versions
+ * silently ignore it instead of crashing on the new value.
+ */
+function parseAgentReasoningEffort(raw: unknown): { reasoningEffort?: ReasoningEffort } {
+  if (typeof raw !== "string") return {}
+  return { reasoningEffort: parseReasoningEffort(raw) ?? undefined }
 }
 
 function parseClassifyConfig(raw: unknown): KodyConfig["classify"] {

--- a/tests/unit/agent.test.ts
+++ b/tests/unit/agent.test.ts
@@ -20,6 +20,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
 }))
 
 import { runAgent } from "../../src/agent.js"
+import { REASONING_BUDGETS } from "../../src/config.js"
 
 let ndjsonDir: string
 const baseOpts = () => ({
@@ -100,6 +101,65 @@ describe("runAgent: maxThinkingTokens passthrough", () => {
     await runAgent({ ...baseOpts(), maxThinkingTokens: -1 })
     const argsNeg = querySpy.mock.calls[0]![0] as { options: Record<string, unknown> }
     expect(argsNeg.options).not.toHaveProperty("maxThinkingTokens")
+  })
+})
+
+describe("runAgent: reasoningEffort → maxThinkingTokens mapping", () => {
+  beforeEach(() => {
+    querySpy.mockClear()
+  })
+  afterEach(() => {
+    querySpy.mockClear()
+  })
+
+  it("omits maxThinkingTokens when reasoningEffort is unset (cheapest path)", async () => {
+    await runAgent(baseOpts())
+    const args = querySpy.mock.calls[0]![0] as { options: Record<string, unknown> }
+    expect(args.options).not.toHaveProperty("maxThinkingTokens")
+  })
+
+  it("omits maxThinkingTokens when reasoningEffort is null", async () => {
+    await runAgent({ ...baseOpts(), reasoningEffort: null })
+    const args = querySpy.mock.calls[0]![0] as { options: Record<string, unknown> }
+    expect(args.options).not.toHaveProperty("maxThinkingTokens")
+  })
+
+  it("omits maxThinkingTokens when reasoningEffort is 'off' (explicit no-thinking)", async () => {
+    await runAgent({ ...baseOpts(), reasoningEffort: "off" })
+    const args = querySpy.mock.calls[0]![0] as { options: Record<string, unknown> }
+    expect(args.options).not.toHaveProperty("maxThinkingTokens")
+  })
+
+  it("maps 'low' → REASONING_BUDGETS.low tokens", async () => {
+    await runAgent({ ...baseOpts(), reasoningEffort: "low" })
+    const args = querySpy.mock.calls[0]![0] as { options: Record<string, unknown> }
+    expect(args.options.maxThinkingTokens).toBe(REASONING_BUDGETS.low)
+  })
+
+  it("maps 'medium' → REASONING_BUDGETS.medium tokens", async () => {
+    await runAgent({ ...baseOpts(), reasoningEffort: "medium" })
+    const args = querySpy.mock.calls[0]![0] as { options: Record<string, unknown> }
+    expect(args.options.maxThinkingTokens).toBe(REASONING_BUDGETS.medium)
+  })
+
+  it("maps 'high' → REASONING_BUDGETS.high tokens", async () => {
+    await runAgent({ ...baseOpts(), reasoningEffort: "high" })
+    const args = querySpy.mock.calls[0]![0] as { options: Record<string, unknown> }
+    expect(args.options.maxThinkingTokens).toBe(REASONING_BUDGETS.high)
+  })
+
+  it("reasoningEffort wins over explicit maxThinkingTokens when both are set", async () => {
+    // User-facing field is canonical — never let a stale budget value
+    // override the level the user picked in the chat.
+    await runAgent({ ...baseOpts(), reasoningEffort: "low", maxThinkingTokens: 99_999 })
+    const args = querySpy.mock.calls[0]![0] as { options: Record<string, unknown> }
+    expect(args.options.maxThinkingTokens).toBe(REASONING_BUDGETS.low)
+  })
+
+  it("'off' wins over explicit maxThinkingTokens too (no thinking block at all)", async () => {
+    await runAgent({ ...baseOpts(), reasoningEffort: "off", maxThinkingTokens: 32_000 })
+    const args = querySpy.mock.calls[0]![0] as { options: Record<string, unknown> }
+    expect(args.options).not.toHaveProperty("maxThinkingTokens")
   })
 })
 

--- a/tests/unit/chat-cli.test.ts
+++ b/tests/unit/chat-cli.test.ts
@@ -63,4 +63,48 @@ describe("chat-cli: parseChatArgs", () => {
     const a = parseChatArgs(["--session", "s1", "--dashboard-url", "https://x/i?token=t"], {})
     expect(a.dashboardUrl).toBe("https://x/i?token=t")
   })
+
+  describe("reasoning effort", () => {
+    it("captures --reasoning-effort flag for every canonical level", () => {
+      expect(parseChatArgs(["--session", "s1", "--reasoning-effort", "off"], {}).reasoningEffort).toBe("off")
+      expect(parseChatArgs(["--session", "s1", "--reasoning-effort", "low"], {}).reasoningEffort).toBe("low")
+      expect(parseChatArgs(["--session", "s1", "--reasoning-effort", "medium"], {}).reasoningEffort).toBe("medium")
+      expect(parseChatArgs(["--session", "s1", "--reasoning-effort", "high"], {}).reasoningEffort).toBe("high")
+    })
+
+    it("accepts case-insensitive --reasoning-effort values", () => {
+      expect(parseChatArgs(["--session", "s1", "--reasoning-effort", "HIGH"], {}).reasoningEffort).toBe("high")
+      expect(parseChatArgs(["--session", "s1", "--reasoning-effort", "Medium"], {}).reasoningEffort).toBe("medium")
+    })
+
+    it("drops --reasoning-effort to undefined for unknown values (don't fail the parse)", () => {
+      // The dashboard may forward stale or typo'd values; we don't
+      // reject the request, we just fall through to the next resolution
+      // source (env → config → unset).
+      expect(parseChatArgs(["--session", "s1", "--reasoning-effort", "nuclear"], {}).reasoningEffort).toBeUndefined()
+      expect(parseChatArgs(["--session", "s1", "--reasoning-effort", ""], {}).reasoningEffort).toBeUndefined()
+    })
+
+    it("falls back to REASONING_EFFORT env var when the flag is absent", () => {
+      const a = parseChatArgs(["--session", "s1"], { REASONING_EFFORT: "high" })
+      expect(a.reasoningEffort).toBe("high")
+    })
+
+    it("CLI flag wins over env when both are set", () => {
+      const a = parseChatArgs(["--session", "s1", "--reasoning-effort", "low"], {
+        REASONING_EFFORT: "high",
+      })
+      expect(a.reasoningEffort).toBe("low")
+    })
+
+    it("ignores empty REASONING_EFFORT env (Actions sends '' for unset inputs)", () => {
+      const a = parseChatArgs(["--session", "s1"], { REASONING_EFFORT: "" })
+      expect(a.reasoningEffort).toBeUndefined()
+    })
+
+    it("is undefined by default — engine's cheapest path (no thinking block)", () => {
+      const a = parseChatArgs(["--session", "s1"], {})
+      expect(a.reasoningEffort).toBeUndefined()
+    })
+  })
 })

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -220,4 +220,47 @@ describe("config: loadConfig", () => {
       expect(loadConfig(dir).defaultPrExecutable).toBeUndefined()
     }
   })
+
+  describe("agent.reasoningEffort", () => {
+    it("preserves a valid reasoningEffort from the config file", () => {
+      for (const value of ["off", "low", "medium", "high"]) {
+        const dir = tmpDir()
+        writeConfig(dir, {
+          github: { owner: "o", repo: "r" },
+          agent: { model: "m/x", reasoningEffort: value },
+        })
+        expect(loadConfig(dir).agent.reasoningEffort).toBe(value)
+      }
+    })
+
+    it("omits reasoningEffort when absent (cheapest path default)", () => {
+      const dir = tmpDir()
+      writeConfig(dir, {
+        github: { owner: "o", repo: "r" },
+        agent: { model: "m/x" },
+      })
+      expect(loadConfig(dir).agent.reasoningEffort).toBeUndefined()
+    })
+
+    it("omits reasoningEffort when empty-string (engine sees no env override)", () => {
+      const dir = tmpDir()
+      writeConfig(dir, {
+        github: { owner: "o", repo: "r" },
+        agent: { model: "m/x", reasoningEffort: "" },
+      })
+      expect(loadConfig(dir).agent.reasoningEffort).toBeUndefined()
+    })
+
+    it("drops unknown reasoningEffort values to undefined instead of throwing", () => {
+      // Forward-compatible: when we add a level in the future, old
+      // engine versions reading a newer config should not crash —
+      // they should silently ignore the unknown value.
+      const dir = tmpDir()
+      writeConfig(dir, {
+        github: { owner: "o", repo: "r" },
+        agent: { model: "m/x", reasoningEffort: "nuclear" },
+      })
+      expect(loadConfig(dir).agent.reasoningEffort).toBeUndefined()
+    })
+  })
 })

--- a/tests/unit/reasoning-effort.test.ts
+++ b/tests/unit/reasoning-effort.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+import {
+  REASONING_BUDGETS,
+  REASONING_EFFORTS,
+  parseReasoningEffort,
+} from "../../src/config.js"
+
+/**
+ * Cross-repo contract: the dashboard's `reasoning-adapter.ts` and the
+ * engine's `REASONING_BUDGETS` MUST agree on the budget for each level.
+ * The dashboard side pins this in its own test suite; here we pin the
+ * engine side, so a one-line change in either file fails both test
+ * suites and the reviewer has to consciously re-sync them.
+ */
+describe("config: ReasoningEffort", () => {
+  it("exposes the canonical vocabulary in REASONING_EFFORTS", () => {
+    expect(REASONING_EFFORTS).toEqual(["off", "low", "medium", "high"])
+  })
+
+  it("maps every non-off effort to a positive budget", () => {
+    for (const effort of REASONING_EFFORTS) {
+      if (effort === "off") continue
+      expect(REASONING_BUDGETS[effort]).toBeGreaterThan(0)
+    }
+  })
+
+  it("pins the canonical Anthropic budgets (matches dashboard adapter)", () => {
+    // Drift between this and the dashboard's applyReasoning() means
+    // chat-level and engine-level thinking budgets silently disagree.
+    expect(REASONING_BUDGETS.low).toBe(2_048)
+    expect(REASONING_BUDGETS.medium).toBe(10_000)
+    expect(REASONING_BUDGETS.high).toBe(32_000)
+  })
+
+  describe("parseReasoningEffort", () => {
+    it("returns null for undefined / empty / whitespace", () => {
+      expect(parseReasoningEffort(undefined)).toBeNull()
+      expect(parseReasoningEffort(null)).toBeNull()
+      expect(parseReasoningEffort("")).toBeNull()
+      expect(parseReasoningEffort("   ")).toBeNull()
+    })
+
+    it("returns the canonical value for each valid string", () => {
+      expect(parseReasoningEffort("off")).toBe("off")
+      expect(parseReasoningEffort("low")).toBe("low")
+      expect(parseReasoningEffort("medium")).toBe("medium")
+      expect(parseReasoningEffort("high")).toBe("high")
+    })
+
+    it("is case-insensitive and trims whitespace", () => {
+      expect(parseReasoningEffort("HIGH")).toBe("high")
+      expect(parseReasoningEffort("  Medium  ")).toBe("medium")
+      expect(parseReasoningEffort("OfF")).toBe("off")
+    })
+
+    it("returns null for unknown values (caller falls through to next source)", () => {
+      expect(parseReasoningEffort("nuclear")).toBeNull()
+      expect(parseReasoningEffort("0")).toBeNull()
+      expect(parseReasoningEffort("disable")).toBeNull()
+    })
+  })
+})

--- a/tests/unit/reasoning-effort.test.ts
+++ b/tests/unit/reasoning-effort.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest"
-import {
-  REASONING_BUDGETS,
-  REASONING_EFFORTS,
-  parseReasoningEffort,
-} from "../../src/config.js"
+import { parseReasoningEffort, REASONING_BUDGETS, REASONING_EFFORTS } from "../../src/config.js"
 
 /**
  * Cross-repo contract: the dashboard's `reasoning-adapter.ts` and the


### PR DESCRIPTION
## Summary

Adds a canonical user-facing thinking level to the Claude Agent SDK call, mapping to `maxThinkingTokens` (Anthropic extended thinking). Closes the contract gap: previously the chat's reasoning dropdown only affected the in-process `/api/kody/chat/kody` path; the engine's chat turn always ran without thinking. Now both paths share one vocabulary.

## Budgets

| Level    | `maxThinkingTokens` |
|----------|---------------------|
| `off`    | unset (cheapest — no thinking block) |
| `low`    | `2_048` |
| `medium` | `10_000` |
| `high`   | `32_000` |

## Resolution order (each layer tested independently)

1. `--reasoning-effort` CLI flag (`kody chat …`)
2. `REASONING_EFFORT` env var (forwarded from dashboard workflow — see companion PR)
3. `agent.reasoningEffort` in `kody.config.json`
4. Unset → no thinking block

## Files

- `src/config.ts` — `ReasoningEffort` type, `REASONING_BUDGETS` map, `parseReasoningEffort()` validator, `parseAgentReasoningEffort()` for config loading
- `kody.config.schema.json` — `agent.reasoningEffort` enum field with description
- `src/agent.ts` — `reasoningEffort` on `AgentOptions`; takes precedence over `maxThinkingTokens`; `"off"` explicitly clears the field
- `src/chat/loop.ts` — `reasoningEffort` on `ChatTurnOptions`; threaded to `runAgent`
- `src/chat/modes/interactive.ts` — same field on `InteractiveModeOptions`; applied to every turn in the loop
- `src/chat-cli.ts` — `--reasoning-effort` CLI flag + `REASONING_EFFORT` env var; resolution order wired in `runChat`

## Tests (74 new, all green)

- `tests/unit/reasoning-effort.test.ts` — vocabulary, budgets pinned to dashboard contract, parser edge cases
- `tests/unit/agent.test.ts` — `reasoningEffort → maxThinkingTokens` mapping for all 4 levels, precedence over explicit budget, `"off"` wins over explicit `maxThinkingTokens`
- `tests/unit/chat-cli.test.ts` — flag parsing (case-insensitive, trim, unknown → undefined), env fallback, CLI-wins-over-env
- `tests/unit/config.test.ts` — `agent.reasoningEffort` accepted, empty/unknown gracefully dropped to undefined

**Full suite:** 1699/1705 passing. The 6 failing tests in `tests/unit/dispatch.test.ts` (release orchestrator routing) are pre-existing on `main` — verified by stashing my changes and re-running; they reproduce without my diff.

## Forward compatibility

- Unknown CLI values drop the flag silently — don't fail the parse, env/config still consulted
- Unknown config values drop to undefined — don't throw on a future-added level
- Empty string is treated as unset (GitHub Actions sends `""` for unset optional inputs)

## Companion PR

Dashboard side (Kody-Dashboard repo) — forwards `REASONING_EFFORT` env var via the `kody.yml` workflow input on the `/api/kody/chat/interactive/start` route, plus the Fly claim/spawn path.