### PR TITLE
fix: resume prepared release promotion

### DIFF
--- a/.github/workflows/kody.yml
+++ b/.github/workflows/kody.yml
@@ -35,6 +35,14 @@ on:
         description: "Initial chat message (optional)"
         type: string
         default: ""
+      duty:
+        description: "Duty action to run (default: run)"
+        type: string
+        default: ""
+      executable:
+        description: "Legacy alias for duty action"
+        type: string
+        default: ""
       model:
         description: "Model override (optional, e.g. anthropic/claude-haiku-4-5-20251001)"
         type: string

--- a/src/executables/release/release.sh
+++ b/src/executables/release/release.sh
@@ -44,6 +44,7 @@ dry_run="${KODY_ARG_DRY_RUN:-false}"
 prefer="${KODY_ARG_PREFER:-}"
 
 default_branch="${KODY_CFG_GIT_DEFAULTBRANCH:-main}"
+release_branch="${KODY_CFG_RELEASE_RELEASEBRANCH:-}"
 notify_cmd="${KODY_CFG_RELEASE_NOTIFYCOMMAND:-}"
 notify_timeout_s=$(( ${KODY_CFG_RELEASE_TIMEOUTMS:-600000} / 1000 ))
 
@@ -67,6 +68,97 @@ if [[ ! -f package.json ]]; then
   echo "KODY_SKIP_AGENT=true"
   exit 1
 fi
+
+read_pkg_version_from_ref() {
+  local ref="$1"
+  git show "${ref}:package.json" 2>/dev/null | node -e 'let s=""; process.stdin.on("data", c => s += c); process.stdin.on("end", () => { try { console.log(JSON.parse(s).version || "") } catch { process.exit(1) } })'
+}
+
+finish_release_with_deploy() {
+  local version="$1"
+  local tag="$2"
+  local release_url="${3:-}"
+
+  current_step="deploy"
+  set +e
+  deploy_pr_url=$(open_deploy_pr "$version" "$issue")
+  deploy_rc=$?
+  set -e
+  if [[ "$deploy_rc" -ne 0 ]]; then
+    echo "[release] deploy step failed (rc=${deploy_rc}) — published v${version} but ${default_branch}→${release_branch} promotion PR was not opened" >&2
+    echo "KODY_REASON=release v${version}: published, but ${default_branch}→${release_branch} deploy PR failed"
+    echo "RELEASE_TAG=${tag}"
+    [[ -n "$release_url" ]] && echo "RELEASE_URL=${release_url}"
+    echo "RELEASE_FAILED=true"
+    exit 1
+  fi
+  if [[ -z "$deploy_pr_url" ]]; then
+    echo " (deploy: no-op — single-branch repo)"
+  else
+    echo "✓ deploy: ${deploy_pr_url}"
+  fi
+
+  current_step="notify"
+  notify_status="skipped"
+  if [[ -n "$notify_cmd" ]]; then
+    cmd="${notify_cmd//\$VERSION/$version}"
+    cmd="${cmd//\$DEPLOY_PR_URL/${deploy_pr_url:-}}"
+    echo " notify: ${cmd}"
+    if timeout "$notify_timeout_s" bash -c "$cmd"; then
+      notify_status="ok"
+    else
+      notify_status="failed"
+      echo "[release] notifyCommand failed (non-fatal)" >&2
+    fi
+  fi
+
+  current_step="done"
+  [[ -n "$deploy_pr_url" ]] && echo "KODY_PR_URL=${deploy_pr_url}"
+  echo "RELEASE_TAG=${tag}"
+  [[ -n "$release_url" ]] && echo "RELEASE_URL=${release_url}"
+  [[ -n "$deploy_pr_url" ]] && echo "RELEASE_DEPLOY_PR=${deploy_pr_url}"
+  echo "KODY_REASON=release v${version} complete (notify=${notify_status})"
+  echo "RELEASE_COMPLETED=true"
+  echo "KODY_SKIP_AGENT=true"
+}
+
+resume_prepared_release_if_needed() {
+  [[ -n "$release_branch" && "$release_branch" != "$default_branch" ]] || return 1
+
+  current_step="resume-check"
+  git fetch origin "$default_branch" "$release_branch" --tags
+
+  local default_version release_version
+  default_version=$(read_pkg_version_from_ref "origin/${default_branch}" || echo "")
+  release_version=$(read_pkg_version_from_ref "origin/${release_branch}" || echo "")
+  [[ -n "$default_version" && -n "$release_version" ]] || return 1
+  [[ "$default_version" != "$release_version" ]] || return 1
+
+  local version="$default_version"
+  local tag="v${version}"
+  echo "→ release: resuming prepared ${tag}; ${default_branch} is not promoted to ${release_branch}"
+
+  current_step="publish"
+  git checkout "$default_branch"
+  git reset --hard "origin/$default_branch"
+
+  local publish_status release_url
+  publish_status=$(tag_and_publish "$version")
+  release_url=$(create_gh_release "$tag" || echo "")
+  echo "✓ publish: tag=${tag} status=${publish_status} release_url=${release_url:-<none>}"
+  if [[ "$publish_status" == "failed" ]]; then
+    echo "[release] publishCommand failed but tag + GH release exist" >&2
+    echo "KODY_REASON=tag + GH release created, but publishCommand failed"
+    echo "RELEASE_FAILED=true"
+    echo "KODY_SKIP_AGENT=true"
+    exit 1
+  fi
+
+  finish_release_with_deploy "$version" "$tag" "$release_url"
+  exit 0
+}
+
+resume_prepared_release_if_needed
 
 # ── 1. Prepare ────────────────────────────────────────────────────────────
 current_step="prepare"
@@ -134,50 +226,5 @@ if [[ "$publish_status" == "failed" ]]; then
   exit 1
 fi
 
-# ── 5. Deploy PR (default → release branch) ───────────────────────────────
-# Distinguish three outcomes: rc!=0 is a real failure (do NOT mask as no-op);
-# rc==0 + empty URL is a genuine single-branch no-op; rc==0 + URL is success.
-current_step="deploy"
-set +e
-deploy_pr_url=$(open_deploy_pr "$new_version" "$issue")
-deploy_rc=$?
-set -e
-release_branch="${KODY_CFG_RELEASE_RELEASEBRANCH:-}"
-if [[ "$deploy_rc" -ne 0 ]]; then
-  echo "[release] deploy step failed (rc=${deploy_rc}) — published v${new_version} but the ${default_branch}→${release_branch} promotion PR was not opened" >&2
-  echo "KODY_REASON=release v${new_version}: published, but the ${default_branch}→${release_branch} deploy PR failed"
-  echo "RELEASE_TAG=${tag}"
-  [[ -n "$release_url" ]] && echo "RELEASE_URL=${release_url}"
-  echo "RELEASE_FAILED=true"
-  exit 1
-fi
-if [[ -z "$deploy_pr_url" ]]; then
-  echo "  (deploy: no-op — single-branch repo)"
-else
-  echo "✓ deploy: ${deploy_pr_url}"
-fi
-
-# ── 6. Notify ─────────────────────────────────────────────────────────────
-current_step="notify"
-notify_status="skipped"
-if [[ -n "$notify_cmd" ]]; then
-  cmd="${notify_cmd//\$VERSION/$new_version}"
-  cmd="${cmd//\$DEPLOY_PR_URL/${deploy_pr_url:-}}"
-  echo "  notify: ${cmd}"
-  if timeout "$notify_timeout_s" bash -c "$cmd"; then
-    notify_status="ok"
-  else
-    notify_status="failed"
-    echo "[release] notifyCommand failed (non-fatal)" >&2
-  fi
-fi
-
-# ── 7. Done ───────────────────────────────────────────────────────────────
-current_step="done"
-[[ -n "$deploy_pr_url" ]] && echo "KODY_PR_URL=${deploy_pr_url}"
-echo "RELEASE_TAG=${tag}"
-[[ -n "$release_url" ]] && echo "RELEASE_URL=${release_url}"
-[[ -n "$deploy_pr_url" ]] && echo "RELEASE_DEPLOY_PR=${deploy_pr_url}"
-echo "KODY_REASON=release v${new_version} complete (notify=${notify_status})"
-echo "RELEASE_COMPLETED=true"
-echo "KODY_SKIP_AGENT=true"
+finish_release_with_deploy "$new_version" "$tag" "$release_url"
+exit 0

--- a/src/scripts/initFlow.ts
+++ b/src/scripts/initFlow.ts
@@ -106,6 +106,16 @@ on:
         description: "GitHub issue number"
         required: true
         type: string
+      duty:
+        description: "Duty action to run (default: run)"
+        required: false
+        type: string
+        default: ""
+      executable:
+        description: "Legacy alias for duty action"
+        required: false
+        type: string
+        default: ""
   issue_comment:
     types: [created]
 

--- a/tests/unit/dispatch.test.ts
+++ b/tests/unit/dispatch.test.ts
@@ -73,6 +73,50 @@ describe("dispatch: workflow_dispatch event", () => {
     })
   })
 
+  it("routes workflow_dispatch duty=release to release executable", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "kody-dispatch-release-workflow-"))
+    const prevCwd = process.cwd()
+    try {
+      process.chdir(tmp)
+      process.env.GITHUB_EVENT_NAME = "workflow_dispatch"
+      process.env.GITHUB_EVENT_PATH = writeEvent({
+        inputs: { issue_number: "291", duty: "release" },
+      })
+      expect(autoDispatch()).toEqual({
+        action: "release",
+        duty: "release",
+        executable: "release",
+        cliArgs: { issue: 291 },
+        target: 291,
+      })
+    } finally {
+      process.chdir(prevCwd)
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it("routes workflow_dispatch executable=release as legacy duty-action input", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "kody-dispatch-release-workflow-"))
+    const prevCwd = process.cwd()
+    try {
+      process.chdir(tmp)
+      process.env.GITHUB_EVENT_NAME = "workflow_dispatch"
+      process.env.GITHUB_EVENT_PATH = writeEvent({
+        inputs: { issue_number: "291", executable: "release" },
+      })
+      expect(autoDispatch()).toEqual({
+        action: "release",
+        duty: "release",
+        executable: "release",
+        cliArgs: { issue: 291 },
+        target: 291,
+      })
+    } finally {
+      process.chdir(prevCwd)
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
   it("returns null for workflow_dispatch with no issue_number — caller fans out via dispatchScheduledWatches(force)", () => {
     process.env.GITHUB_EVENT_NAME = "workflow_dispatch"
     process.env.GITHUB_EVENT_PATH = writeEvent({ inputs: {} })

--- a/tests/unit/release-script-resume.test.ts
+++ b/tests/unit/release-script-resume.test.ts
@@ -1,0 +1,79 @@
+import { execFileSync } from "node:child_process"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const repoRoot = path.resolve(__dirname, "../..")
+
+function writeExecutable(file: string, body: string) {
+  fs.writeFileSync(file, body)
+  fs.chmodSync(file, 0o755)
+}
+
+describe("release.sh resume behavior", () => {
+  it("opens the deploy PR for an already-prepared default branch release", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "kody-release-resume-"))
+    try {
+      const releaseDir = path.join(tmp, "release")
+      const binDir = path.join(tmp, "bin")
+      fs.mkdirSync(releaseDir)
+      fs.mkdirSync(binDir)
+      fs.copyFileSync(path.join(repoRoot, "src/executables/release/release.sh"), path.join(releaseDir, "release.sh"))
+      fs.chmodSync(path.join(releaseDir, "release.sh"), 0o755)
+
+      fs.writeFileSync(path.join(tmp, "package.json"), JSON.stringify({ version: "1.2.3" }))
+      fs.writeFileSync(
+        path.join(releaseDir, "prepare.sh"),
+        [
+          'read_pkg_version() { echo "1.2.3"; }',
+          'bump_version() { echo "9.9.9"; }',
+          'open_prepare_pr() { echo "SHOULD_NOT_PREPARE"; return 99; }',
+          "set_kody_release_pr_marker() { :; }",
+          "",
+        ].join("\n"),
+      )
+      fs.writeFileSync(path.join(releaseDir, "wait.sh"), "wait_for_ci() { :; }\n")
+      fs.writeFileSync(
+        path.join(releaseDir, "publish.sh"),
+        'tag_and_publish() { echo "ok"; }\ncreate_gh_release() { echo "https://example.test/releases/$1"; }\n',
+      )
+      fs.writeFileSync(
+        path.join(releaseDir, "deploy.sh"),
+        'open_deploy_pr() { echo "https://example.test/pr/$1/$2"; }\n',
+      )
+
+      writeExecutable(
+        path.join(binDir, "git"),
+        [
+          "#!/usr/bin/env bash",
+          'if [[ "$1" == "fetch" ]]; then exit 0; fi',
+          'if [[ "$1" == "show" && "$2" == "origin/dev:package.json" ]]; then echo \'{"version":"1.2.3"}\'; exit 0; fi',
+          'if [[ "$1" == "show" && "$2" == "origin/main:package.json" ]]; then echo \'{"version":"1.2.2"}\'; exit 0; fi',
+          'if [[ "$1" == "checkout" || "$1" == "reset" ]]; then exit 0; fi',
+          'echo "unexpected git $*" >&2',
+          "exit 1",
+          "",
+        ].join("\n"),
+      )
+
+      const out = execFileSync(path.join(releaseDir, "release.sh"), {
+        cwd: tmp,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          KODY_ARG_ISSUE: "291",
+          KODY_CFG_GIT_DEFAULTBRANCH: "dev",
+          KODY_CFG_RELEASE_RELEASEBRANCH: "main",
+        },
+      })
+
+      expect(out).toContain("resuming prepared v1.2.3")
+      expect(out).toContain("KODY_PR_URL=https://example.test/pr/1.2.3/291")
+      expect(out).not.toContain("SHOULD_NOT_PREPARE")
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Resume the release flow at deploy PR creation when the integration branch already has an unpromoted package version.
- Reuse the deploy/notify/done path for normal and resumed release flows.
- Add explicit duty/executable workflow_dispatch inputs and regression coverage for release dispatch.

## Verification
- pnpm typecheck
- bash -n src/executables/release/release.sh
- pnpm exec biome check .github/workflows/kody.yml src/scripts/initFlow.ts tests/unit/dispatch.test.ts tests/unit/release-script-resume.test.ts
- pnpm exec vitest run tests/unit/dispatch.test.ts tests/unit/release-script-resume.test.ts --no-coverage
- pnpm exec vitest run tests/unit --no-coverage

## Notes
- Full pnpm lint currently fails on unrelated dirty worktree files not included in this PR: src/companyStore.ts, src/registry.ts, src/scripts/dispatchDutyFileTicks.ts, src/scripts/loadJobFromFile.ts, src/scripts/loadWorkerAdhoc.ts, src/staff.ts.
