### PR TITLE
fix(engine): route loop run requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kody-ade/kody-engine",
-  "version": "0.4.508",
+  "version": "0.4.509",
   "description": "kody — autonomous development engine. Single-session Claude Code agent behind a generic executor + declarative implementation profiles.",
   "license": "MIT",
   "type": "module",

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -68,7 +68,9 @@ function envRunRequest(env: NodeJS.ProcessEnv = process.env): ParsedArgs | null 
   const { target } = parsed.request
   if (target.type === "chat") return { ...result, command: "chat", chatArgv: [] }
   if (target.type === "issue") return { ...result, command: "ci", ciArgv: ["--issue", String(target.id)] }
-  if (target.type === "goal" || target.type === "workflow") return { ...result, command: "ci", ciArgv: [] }
+  if (target.type === "goal" || target.type === "loop" || target.type === "workflow") {
+    return { ...result, command: "ci", ciArgv: [] }
+  }
 
   return { ...result, errors: [`unsupported runRequest target: ${(target as { type?: string }).type ?? "unknown"}`] }
 }

--- a/tests/unit/entry.test.ts
+++ b/tests/unit/entry.test.ts
@@ -162,6 +162,23 @@ describe("entry: parseArgs", () => {
     expect(a.ciArgv).toEqual([])
   })
 
+  it("routes bare runner loop requests to ci", () => {
+    vi.stubEnv(
+      "KODY_RUN_REQUEST_JSON",
+      JSON.stringify({
+        requestId: "loop-request-1",
+        target: { type: "loop", id: "daily-web-release-loop" },
+        intent: "run",
+        source: "dashboard",
+      }),
+    )
+
+    const a = parseArgs([])
+
+    expect(a.command).toBe("ci")
+    expect(a.ciArgv).toEqual([])
+  })
+
   it("routes bare runner interactive mode to chat", () => {
     vi.stubEnv("KODY_RUN_MODE", "interactive")
 


### PR DESCRIPTION
## What / Why

Allow canonical loop run requests to enter CI routing, matching the loop handling already implemented in `kody-cli`.

## Scope

- route `target.type: loop` through CI
- add regression coverage
- bump package to 0.4.509

## Verification

- `pnpm vitest run tests/unit/entry.test.ts` — passed
- `pnpm typecheck` — passed
- `pnpm test` — passed
- `pnpm test:e2e` — passed (one environment-dependent test skipped)
- `pnpm test:runtime-services` — passed
- focused Biome check — passed
- `pnpm build` — passed
- `pnpm verify:package` — passed

Full repository Biome check remains blocked by pre-existing formatting findings outside this change.