### PR TITLE
feat(release): activate daily package releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: ci
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: [main]

--- a/kody.config.json
+++ b/kody.config.json
@@ -14,10 +14,30 @@
     "typecheck": "pnpm typecheck",
     "testUnit": "pnpm test"
   },
+  "release": {
+    "validation": {
+      "workflow": "ci.yml"
+    },
+    "versionFiles": [
+      "package.json"
+    ],
+    "productionDeployRequired": false,
+    "timeoutMs": 1800000
+  },
   "company": {
+    "activeCapabilities": [
+      "release-prepare",
+      "release-validate",
+      "release-merge",
+      "npm-publish"
+    ],
     "activeGoals": [
       "ci-health",
-      "prs-stay-mergeable"
+      "prs-stay-mergeable",
+      "daily-package-release-loop"
+    ],
+    "activeWorkflows": [
+      "package-release"
     ]
   }
 }

--- a/tests/unit/packageReleaseConfig.test.ts
+++ b/tests/unit/packageReleaseConfig.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+import { loadConfig } from "../../src/config.js"
+
+describe("package release loop configuration", () => {
+  it("activates the Store package release bundle", () => {
+    const config = loadConfig(process.cwd())
+
+    expect(config.company?.activeGoals).toContain("daily-package-release-loop")
+    expect(config.company?.activeCapabilities).toEqual(
+      expect.arrayContaining(["release-prepare", "release-validate", "release-merge", "npm-publish"]),
+    )
+    expect(config.release?.validation?.workflow).toBe("ci.yml")
+  })
+
+  it("allows the release workflow to dispatch exact-branch validation", () => {
+    const workflow = readFileSync(".github/workflows/ci.yml", "utf8")
+
+    expect(workflow).toMatch(/workflow_dispatch:/)
+  })
+})


### PR DESCRIPTION
## Summary
- activate the Store-owned daily package release loop
- configure ci.yml as the release validation workflow
- make CI manually dispatchable for release validation
- add a focused configuration contract test

## Validation
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm test:e2e (suite currently skipped)
- Biome check on changed test
- Store definition resolution for loop, workflow, and npm-publish capability

## Known baseline
- pnpm lint still reports 12 pre-existing formatting errors in unrelated files