### PR TITLE
feat(release): enable package release loop

### DIFF
--- a/.kody-engine/definitions/loops/daily-package-release-loop/loop.json
+++ b/.kody-engine/definitions/loops/daily-package-release-loop/loop.json
@@ -1,0 +1,13 @@
+{
+  "id": "daily-package-release-loop",
+  "trigger": {
+    "type": "schedule",
+    "every": "1d"
+  },
+  "target": {
+    "kind": "workflow",
+    "id": "package-release"
+  },
+  "input": {},
+  "enabled": true
+}

--- a/tests/unit/packageReleaseConfig.test.ts
+++ b/tests/unit/packageReleaseConfig.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs"
 import { describe, expect, it } from "vitest"
 import { loadConfig } from "../../src/config.js"
+import { readLoopDefinition } from "../../src/loopDefinitions.js"
 
 describe("package release loop configuration", () => {
   it("activates the Store package release bundle", () => {
@@ -17,5 +18,16 @@ describe("package release loop configuration", () => {
     const workflow = readFileSync(".github/workflows/ci.yml", "utf8")
 
     expect(workflow).toMatch(/workflow_dispatch:/)
+  })
+
+  it("enables the repository-owned daily package release loop", () => {
+    const loop = readLoopDefinition(process.cwd(), "daily-package-release-loop")
+
+    expect(loop).toMatchObject({
+      id: "daily-package-release-loop",
+      enabled: true,
+      trigger: { type: "schedule", every: "1d" },
+      target: { kind: "workflow", id: "package-release" },
+    })
   })
 })


### PR DESCRIPTION
## Summary
- add the repository-owned daily package release loop with enabled=true
- keep the Store catalog copy disabled as the reusable safe template
- test the actual runtime loop resolution and schedule

## Validation
- focused package release config test: 3 passed
- pnpm typecheck
- pnpm test
- Biome check on changed test

## Baseline
- repository-wide lint still has the same 12 unrelated errors present on main