### PR TITLE
fix(ci): restore release validation gates

### DIFF
--- a/src/agency/capability-contract-validation.ts
+++ b/src/agency/capability-contract-validation.ts
@@ -15,16 +15,13 @@ export class CapabilityContractValidationError extends Error {
       .map((error) => {
         const location = error.instancePath || "$"
         const property =
-          error.keyword === "additionalProperties" &&
-          typeof error.params.additionalProperty === "string"
+          error.keyword === "additionalProperties" && typeof error.params.additionalProperty === "string"
             ? ` (${error.params.additionalProperty})`
             : ""
         return `${location}: ${error.message ?? error.keyword}${property}`
       })
       .join("; ")
-    super(
-      `Capability ${boundary} does not match its declared contract: ${details}`,
-    )
+    super(`Capability ${boundary} does not match its declared contract: ${details}`)
     this.name = "CapabilityContractValidationError"
   }
 }
@@ -46,9 +43,7 @@ export function capabilityContractInput(
   capabilityId?: string,
   contractProperties: readonly string[] = [],
 ): unknown {
-  const isGenericRunnerInput =
-    inputs.some((input) => input.name === "input") &&
-    Object.hasOwn(args, "input")
+  const isGenericRunnerInput = inputs.some((input) => input.name === "input") && Object.hasOwn(args, "input")
   if (!isGenericRunnerInput) {
     const isParameterlessGenericRunner =
       (inputs.some((input) => input.name === "capability") ||

--- a/src/capabilityFolders.ts
+++ b/src/capabilityFolders.ts
@@ -226,9 +226,7 @@ function parseCapabilityContract(raw: string): CapabilityContract {
       ? undefined
       : Array.isArray(parsed.requiredSubagents) &&
           parsed.requiredSubagents.length > 0 &&
-          parsed.requiredSubagents.every(
-            (name) => typeof name === "string" && /^[a-z][a-z0-9-]{0,63}$/.test(name),
-          )
+          parsed.requiredSubagents.every((name) => typeof name === "string" && /^[a-z][a-z0-9-]{0,63}$/.test(name))
         ? [...new Set(parsed.requiredSubagents as string[])]
         : null
   if (requiredSubagents === null) {

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -332,11 +332,7 @@ export async function runImplementation(profileName: string, input: ExecutorInpu
           profile.inputs,
           args,
           profile.canonicalContract.capabilityId,
-          Object.keys(
-            (profile.canonicalContract.inputSchema.properties as
-              | Record<string, unknown>
-              | undefined) ?? {},
-          ),
+          Object.keys((profile.canonicalContract.inputSchema.properties as Record<string, unknown> | undefined) ?? {}),
         ),
       )
     }

--- a/src/kody-cli.ts
+++ b/src/kody-cli.ts
@@ -582,20 +582,21 @@ export async function runCi(argv: string[]): Promise<number> {
     const capabilityRoot = capabilitiesRoot(cwd)
     const directCapability = manualGoalManager ? null : resolveCapabilityFolder(forceRunAction, capabilityRoot)
     const directExecution = directCapability ? resolveCapabilityExecution(directCapability, cwd) : null
-    const capabilityRoute = manualGoalManager || forceRunTargetKind === "workflow"
-      ? null
-      : (resolveCapabilityAction(forceRunAction, capabilityRoot) ??
-        (directCapability &&
-        directExecution &&
-        (directCapability.config.action ?? directCapability.slug) === forceRunAction
-          ? {
-              action: forceRunAction,
-              capability: directCapability.slug,
-              implementation: directExecution.implementation,
-              cliArgs: directExecution.cliArgs,
-              source: "project-folder" as const,
-            }
-          : null))
+    const capabilityRoute =
+      manualGoalManager || forceRunTargetKind === "workflow"
+        ? null
+        : (resolveCapabilityAction(forceRunAction, capabilityRoot) ??
+          (directCapability &&
+          directExecution &&
+          (directCapability.config.action ?? directCapability.slug) === forceRunAction
+            ? {
+                action: forceRunAction,
+                capability: directCapability.slug,
+                implementation: directExecution.implementation,
+                cliArgs: directExecution.cliArgs,
+                source: "project-folder" as const,
+              }
+            : null))
     const workflowRoute =
       manualGoalManager ||
       capabilityRoute ||

--- a/src/scripts/capabilityExecutionEnvironment.ts
+++ b/src/scripts/capabilityExecutionEnvironment.ts
@@ -5,9 +5,7 @@
  * - KODY_ARG_* contains the current invocation input.
  * - KODY_CFG_* contains repository-owned Engine configuration.
  */
-export function capabilityInputEnvironment(
-  input: unknown,
-): Record<string, string> {
+export function capabilityInputEnvironment(input: unknown): Record<string, string> {
   const environment: Record<string, string> = {
     KODY_CAPABILITY_INPUT: JSON.stringify(input ?? null),
   }
@@ -17,46 +15,29 @@ export function capabilityInputEnvironment(
   for (const [name, value] of Object.entries(input)) {
     if (value === undefined || value === null) continue
     const key = environmentKey(name)
-    environment[`KODY_ARG_${key}`] =
-      typeof value === "string" ? value : JSON.stringify(value)
+    environment[`KODY_ARG_${key}`] = typeof value === "string" ? value : JSON.stringify(value)
   }
   return environment
 }
 
-export function capabilityConfigEnvironment(
-  config: unknown,
-): Record<string, string> {
+export function capabilityConfigEnvironment(config: unknown): Record<string, string> {
   if (!config || typeof config !== "object" || Array.isArray(config)) return {}
   return Object.fromEntries(
-    flattenConfig(config as Record<string, unknown>).map(([key, value]) => [
-      `KODY_CFG_${key}`,
-      value,
-    ]),
+    flattenConfig(config as Record<string, unknown>).map(([key, value]) => [`KODY_CFG_${key}`, value]),
   )
 }
 
-function flattenConfig(
-  config: Record<string, unknown>,
-  prefix = "",
-): Array<[string, string]> {
+function flattenConfig(config: Record<string, unknown>, prefix = ""): Array<[string, string]> {
   const entries: Array<[string, string]> = []
   for (const [name, value] of Object.entries(config)) {
     if (value === null || value === undefined) continue
-    const key = prefix
-      ? `${prefix}_${environmentKey(name)}`
-      : environmentKey(name)
-    if (
-      typeof value === "string" ||
-      typeof value === "number" ||
-      typeof value === "boolean"
-    ) {
+    const key = prefix ? `${prefix}_${environmentKey(name)}` : environmentKey(name)
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
       entries.push([key, String(value)])
     } else if (Array.isArray(value)) {
       entries.push([key, JSON.stringify(value)])
     } else if (typeof value === "object") {
-      entries.push(
-        ...flattenConfig(value as Record<string, unknown>, key),
-      )
+      entries.push(...flattenConfig(value as Record<string, unknown>, key))
     }
   }
   return entries

--- a/src/scripts/dispatchLoops.ts
+++ b/src/scripts/dispatchLoops.ts
@@ -57,9 +57,7 @@ export const dispatchLoops: PreflightScript = async (ctx) => {
 export function assertLoopDispatchesSucceeded(results: readonly LoopDispatchResult[]): void {
   const failed = results.filter((result) => result.status === "failed")
   if (failed.length === 0) return
-  throw new Error(
-    `Loop dispatch failed: ${failed.map((result) => `${result.loopId}: ${result.reason}`).join("; ")}`,
-  )
+  throw new Error(`Loop dispatch failed: ${failed.map((result) => `${result.loopId}: ${result.reason}`).join("; ")}`)
 }
 
 export async function dispatchLoopsWith(input: {

--- a/src/scripts/loadSimpleCapability.ts
+++ b/src/scripts/loadSimpleCapability.ts
@@ -1,7 +1,7 @@
-import * as fs from "node:fs"
-import * as path from "node:path"
-import * as os from "node:os"
 import { randomUUID } from "node:crypto"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
 import { validateCapabilityContractValue } from "../agency/capability-contract-validation.js"
 import { readCapabilityFolder } from "../capabilityFolders.js"
 import { capabilitiesRoot } from "../definition-paths.js"
@@ -22,10 +22,7 @@ export const loadSimpleCapability: PreflightScript = async (ctx, profile) => {
   const toolFiles = listFiles(toolRoot)
   const skillFiles = listFiles(skillRoot)
   const parsedInput = parseInput(ctx.args.input)
-  const input =
-    parsedInput === undefined && capability.config.inputSchema?.type === "object"
-      ? {}
-      : parsedInput
+  const input = parsedInput === undefined && capability.config.inputSchema?.type === "object" ? {} : parsedInput
   if (capability.config.inputSchema) {
     validateCapabilityContractValue("input", capability.config.inputSchema, input)
   }

--- a/src/scripts/parseSimpleCapabilityOutput.ts
+++ b/src/scripts/parseSimpleCapabilityOutput.ts
@@ -26,8 +26,7 @@ export const parseSimpleCapabilityOutput: PostflightScript = async (ctx, _profil
     ]
     return
   }
-  const outputPath =
-    typeof ctx.data.capabilityOutputPath === "string" ? ctx.data.capabilityOutputPath : undefined
+  const outputPath = typeof ctx.data.capabilityOutputPath === "string" ? ctx.data.capabilityOutputPath : undefined
   const fileOutput = readOutputFile(outputPath)
   const output = fileOutput.found
     ? fileOutput.value

--- a/tests/smoke/cli.test.ts
+++ b/tests/smoke/cli.test.ts
@@ -52,8 +52,9 @@ describe("smoke: CLI boots and validates args", () => {
 
     expect(r.status).toBe(0)
     const workflow = fs.readFileSync(path.join(root, ".github", "workflows", "kody.yml"), "utf8")
-    expect(workflow).toContain("kody-engine ci --cwd")
-    expect(workflow).toContain('cron: "7/15 * * * *"')
+    expect(workflow).toContain("npx -y -p @kody-ade/kody-engine@latest kody-engine")
+    expect(workflow).toContain("KODY_RUN_REQUEST_JSON: ${{ inputs.runRequest }}")
+    expect(workflow).toContain("cron: '7/15 * * * *'")
     expect(workflow).not.toContain("KODY_DEFINITIONS_ROOT:")
     expect(workflow).not.toContain("Hydrate Kody Store definitions")
     expect(workflow).not.toContain("actions/setup-python")

--- a/tests/unit/capability-contract-validation.test.ts
+++ b/tests/unit/capability-contract-validation.test.ts
@@ -31,52 +31,34 @@ describe("Capability contract validation", () => {
 
   it("unwraps and parses the generic runner input before contract validation", () => {
     expect(
-      capabilityContractInput(
-        [{ name: "capability" }, { name: "input" }],
-        { capability: "inspect", input: '{"issue":42}' },
-      ),
+      capabilityContractInput([{ name: "capability" }, { name: "input" }], {
+        capability: "inspect",
+        input: '{"issue":42}',
+      }),
     ).toEqual({ issue: 42 })
   })
 
   it("unwraps the single generic input used by hydrated Store capabilities", () => {
-    expect(
-      capabilityContractInput(
-        [{ name: "input" }],
-        { input: '{"issue":42}' },
-      ),
-    ).toEqual({ issue: 42 })
+    expect(capabilityContractInput([{ name: "input" }], { input: '{"issue":42}' })).toEqual({ issue: 42 })
   })
 
   it("unwraps generic input when the implementation also declares routing inputs", () => {
     expect(
-      capabilityContractInput(
-        [{ name: "input" }, { name: "base" }],
-        { input: '{"issue":42}', base: "main" },
-      ),
+      capabilityContractInput([{ name: "input" }, { name: "base" }], { input: '{"issue":42}', base: "main" }),
     ).toEqual({ issue: 42 })
   })
 
   it("uses empty business input for a parameterless generic runner invocation", () => {
-    expect(
-      capabilityContractInput(
-        [{ name: "input" }],
-        { capability: "inspect" },
-        "inspect",
-      ),
-    ).toEqual({})
+    expect(capabilityContractInput([{ name: "input" }], { capability: "inspect" }, "inspect")).toEqual({})
   })
 
   it("keeps capability when the business contract explicitly declares it", () => {
     const args = { capability: "business-value" }
-    expect(
-      capabilityContractInput([], args, "runner", ["capability"]),
-    ).toBe(args)
+    expect(capabilityContractInput([], args, "runner", ["capability"])).toBe(args)
   })
 
   it("keeps ordinary named capability inputs unchanged", () => {
     const args = { issue: 42 }
-    expect(
-      capabilityContractInput([{ name: "issue" }], args),
-    ).toBe(args)
+    expect(capabilityContractInput([{ name: "issue" }], args)).toBe(args)
   })
 })

--- a/tests/unit/dispatchLoops.test.ts
+++ b/tests/unit/dispatchLoops.test.ts
@@ -189,9 +189,7 @@ describe("dispatchLoopsWith", () => {
 describe("assertLoopDispatchesSucceeded", () => {
   it("fails the outer CI run when any Loop target failed", () => {
     expect(() =>
-      assertLoopDispatchesSucceeded([
-        { loopId: "daily-check", status: "failed", reason: "target missing" },
-      ]),
+      assertLoopDispatchesSucceeded([{ loopId: "daily-check", status: "failed", reason: "target missing" }]),
     ).toThrow("Loop dispatch failed: daily-check: target missing")
   })
 

--- a/tests/unit/kody-cli-manual-goal.test.ts
+++ b/tests/unit/kody-cli-manual-goal.test.ts
@@ -170,13 +170,7 @@ describe("kody-cli manual goal dispatch", () => {
   it("keeps an explicit workflow target when a capability has the same id", async () => {
     const dir = tmpDir()
     writeConfig(dir)
-    const capabilityDir = path.join(
-      dir,
-      ".kody-engine",
-      "definitions",
-      "capabilities",
-      "build-knowledge",
-    )
+    const capabilityDir = path.join(dir, ".kody-engine", "definitions", "capabilities", "build-knowledge")
     fs.mkdirSync(capabilityDir, { recursive: true })
     fs.writeFileSync(path.join(capabilityDir, "instructions.md"), "Build knowledge.\n")
     fs.writeFileSync(


### PR DESCRIPTION
## What / Why
Restore the CI gates required by the package-release workflow.

## Scope
- apply the repository formatter to the 11 files blocking lint
- update the stale CLI smoke expectation to the current generated launcher
- no release behavior changes

## Validation
- pnpm lint: passed (warnings only)
- pnpm typecheck: passed
- pnpm test: passed
- pnpm test:smoke: 11 passed
- pnpm test:e2e: passed (1 intentionally skipped)
- pnpm build: passed