### PR TITLE
chore: release v0.4.511

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.511 — 2026-08-01
+
+### Fixes
+- restore release validation gates (#74) (d5075de)
 All notable changes to `@kody-ade/kody-engine` are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kody-ade/kody-engine",
-  "version": "0.4.510",
-  "description": "kody — autonomous development engine. Single-session Claude Code agent behind a generic executor + declarative implementation profiles.",
+  "version": "0.4.511",
+  "description": "kody \u2014 autonomous development engine. Single-session Claude Code agent behind a generic executor + declarative implementation profiles.",
   "license": "MIT",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Automated release PR opened by kody.

## v0.4.511 — 2026-08-01

### Fixes
- restore release validation gates (#74) (d5075de)

The release orchestrator will merge this into `main` and continue to publish + deploy.