### PR TITLE
chore: release v0.4.513

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.4.513 — 2026-08-02
+
+### Features
+- install observer self-management pilot (532bb4a)
+- support test coverage gates (4be311c)
+
+### Chores
+- update catalog repository (7cd192b)
+- install test health solution (59a501c)
 ## v0.4.512 — 2026-08-02
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kody-ade/kody-engine",
-  "version": "0.4.512",
+  "version": "0.4.513",
   "description": "kody \u2014 autonomous development engine. Single-session Claude Code agent behind a generic executor + declarative implementation profiles.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Automated release PR opened by kody.

## v0.4.513 — 2026-08-02

### Features
- install observer self-management pilot (532bb4a)
- support test coverage gates (4be311c)

### Chores
- update catalog repository (7cd192b)
- install test health solution (59a501c)

The release orchestrator will merge this into `main` and continue to publish + deploy.