### PR TITLE
chore: release v0.4.520

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.4.520 — 2026-08-02
+
+### Features
+- publish run summary reports (2a0878c)
+
+### Fixes
+- keep publish gate self-contained (c9f11e1)
+- isolate prepublish tests (ed8fc29)
+
+### Chores
+- restore release lint gate (00c4bec)
 ## v0.4.519 — 2026-08-02
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kody-ade/kody-engine",
-  "version": "0.4.519",
+  "version": "0.4.520",
   "description": "kody \u2014 autonomous development engine. Single-session Claude Code agent behind a generic executor + declarative implementation profiles.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Automated release PR opened by kody.

## v0.4.520 — 2026-08-02

### Features
- publish run summary reports (2a0878c)

### Fixes
- keep publish gate self-contained (c9f11e1)
- isolate prepublish tests (ed8fc29)

### Chores
- restore release lint gate (00c4bec)

The release orchestrator will merge this into `main` and continue to publish + deploy.