### PR TITLE
chore: release v0.4.526

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.4.526 — 2026-08-03
+
+### Features
+- support user-owned conversation tenants (4bab9b6)
+- publish run summary reports (2a0878c)
+
+### Fixes
+- avoid repeated capability facts (d6c39a7)
+- publish simple capability facts (3592d99)
+- preserve typed inputs (615b72e)
+- publish readable markdown only (0b72c53)
+- preserve summary report config (006dfe7)
+- keep publish gate self-contained (c9f11e1)
+- isolate prepublish tests (ed8fc29)
+
+### Chores
+- restore release lint gate (00c4bec)
 ## v0.4.525 — 2026-08-02
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kody-ade/kody-engine",
-  "version": "0.4.525",
+  "version": "0.4.526",
   "description": "kody \u2014 autonomous development engine. Single-session Claude Code agent behind a generic executor + declarative implementation profiles.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Automated release PR opened by kody.

## v0.4.526 — 2026-08-03

### Features
- support user-owned conversation tenants (4bab9b6)
- publish run summary reports (2a0878c)

### Fixes
- avoid repeated capability facts (d6c39a7)
- publish simple capability facts (3592d99)
- preserve typed inputs (615b72e)
- publish readable markdown only (0b72c53)
- preserve summary report config (006dfe7)
- keep publish gate self-contained (c9f11e1)
- isolate prepublish tests (ed8fc29)

### Chores
- restore release lint gate (00c4bec)

The release orchestrator will merge this into `main` and continue to publish + deploy.