### PR TITLE
chore: release v0.4.538

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.4.538 — 2026-08-09
+
+### Features
+- expose generic workflow facts (8d11828)
+
+### Other
+- use review fix workflow name (eb93b15)
 ## v0.4.532 — 2026-08-08
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kody-ade/kody-engine",
-  "version": "0.4.537",
+  "version": "0.4.538",
   "description": "kody \u2014 autonomous development engine. Single-session Claude Code agent behind a generic executor + declarative implementation profiles.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Automated release PR opened by kody.

## v0.4.538 — 2026-08-09

### Features
- expose generic workflow facts (8d11828)

### Other
- use review fix workflow name (eb93b15)

The release orchestrator will merge this into `main` and continue to publish + deploy.