### PR TITLE
chore: release v0.4.549

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.4.549 — 2026-08-10
+
+_No notable commits since the last release._
 ## v0.4.532 — 2026-08-08
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kody-ade/kody-engine",
-  "version": "0.4.548",
+  "version": "0.4.549",
   "description": "kody \u2014 autonomous development engine. Single-session Claude Code agent behind a generic executor + declarative implementation profiles.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Automated release PR opened by kody.

## v0.4.549 — 2026-08-10

_No notable commits since the last release._

The release orchestrator will merge this into `main` and continue to publish + deploy.