### PR TITLE
chore: release v0.4.575

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.4.575 — 2026-08-13
+
+### Fixes
+- accept pipeline run requests (7c77ba9)
+- enforce shared execution contract (f00a724)
+- support draft checkpoints (cd6fe15)
+- preserve finalization window (26b085d)
+- reserve time for completion (d12c9a3)
+
+### Chores
+- add store pipeline ci-repair (d92461e)
+- add store workflow merge (6784bea)
+- add store workflow review-fix (1e2c929)
+- add store workflow ci-repair (b52c915)
+
+### Other
+- require repeatable CI repair proof (93cc4fd)
 ## v0.4.532 — 2026-08-08
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kody-ade/kody-engine",
-  "version": "0.4.574",
-  "description": "kody — autonomous development engine. Single-session Claude Code agent behind a generic executor + declarative implementation profiles.",
+  "version": "0.4.575",
+  "description": "kody \u2014 autonomous development engine. Single-session Claude Code agent behind a generic executor + declarative implementation profiles.",
   "license": "MIT",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Automated release PR opened by kody.

## v0.4.575 — 2026-08-13

### Fixes
- accept pipeline run requests (7c77ba9)
- enforce shared execution contract (f00a724)
- support draft checkpoints (cd6fe15)
- preserve finalization window (26b085d)
- reserve time for completion (d12c9a3)

### Chores
- add store pipeline ci-repair (d92461e)
- add store workflow merge (6784bea)
- add store workflow review-fix (1e2c929)
- add store workflow ci-repair (b52c915)

### Other
- require repeatable CI repair proof (93cc4fd)

The release orchestrator will merge this into `main` and continue to publish + deploy.