### PR TITLE
chore: release v0.4.598

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.4.598 — 2026-08-17
+
+### Fixes
+- route automatic models through fallback gateway (9979d17)
+
+### Chores
+- release 0.4.597 (2711d59)
 ## v0.4.532 — 2026-08-08
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kody-ade/kody-engine",
-  "version": "0.4.597",
-  "description": "kody — autonomous development engine. Single-session Claude Code agent behind a generic executor + declarative implementation profiles.",
+  "version": "0.4.598",
+  "description": "kody \u2014 autonomous development engine. Single-session Claude Code agent behind a generic executor + declarative implementation profiles.",
   "license": "MIT",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Automated release PR opened by kody.

## v0.4.598 — 2026-08-17

### Fixes
- route automatic models through fallback gateway (9979d17)

### Chores
- release 0.4.597 (2711d59)

The release orchestrator will merge this into `main` and continue to publish + deploy.