### PR TITLE
chore: release v0.4.602

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.4.602 — 2026-08-18
+
+### Fixes
+- defer QA user identity lookup (bb888db)
+- retry temporary QA login failures (a55b70f)
+- stop after valid capability output (2c872bd)
+- prepare authenticated QA browser (d1dfe99)
+- route automatic models through fallback gateway (9979d17)
+
+### Chores
+- release 0.4.597 (2711d59)
 ## v0.4.532 — 2026-08-08
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kody-ade/kody-engine",
-  "version": "0.4.601",
-  "description": "kody — autonomous development engine. Single-session Claude Code agent behind a generic executor + declarative implementation profiles.",
+  "version": "0.4.602",
+  "description": "kody \u2014 autonomous development engine. Single-session Claude Code agent behind a generic executor + declarative implementation profiles.",
   "license": "MIT",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Automated release PR opened by kody.

## v0.4.602 — 2026-08-18

### Fixes
- defer QA user identity lookup (bb888db)
- retry temporary QA login failures (a55b70f)
- stop after valid capability output (2c872bd)
- prepare authenticated QA browser (d1dfe99)
- route automatic models through fallback gateway (9979d17)

### Chores
- release 0.4.597 (2711d59)

The release orchestrator will merge this into `main` and continue to publish + deploy.