### PR TITLE
chore: release v0.4.608

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.4.608 — 2026-08-19
+
+### Fixes
+- select account chat model (e9900a6)
+- load account credential requirements (059d4e3)
+- provision account model credentials (ac62a0e)
+- persist repository login for test accounts (2facfbd)
+- preserve combined browser authentication (fe30022)
+- prepare app login before browser tests (fb22b96)
+- defer QA user identity lookup (bb888db)
+- retry temporary QA login failures (a55b70f)
+- stop after valid capability output (2c872bd)
+- prepare authenticated QA browser (d1dfe99)
+- route automatic models through fallback gateway (9979d17)
+
+### Chores
+- release 0.4.597 (2711d59)
 ## v0.4.532 — 2026-08-08
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kody-ade/kody-engine",
-  "version": "0.4.607",
-  "description": "kody — autonomous development engine. Single-session Claude Code agent behind a generic executor + declarative implementation profiles.",
+  "version": "0.4.608",
+  "description": "kody \u2014 autonomous development engine. Single-session Claude Code agent behind a generic executor + declarative implementation profiles.",
   "license": "MIT",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Automated release PR opened by kody.

## v0.4.608 — 2026-08-19

### Fixes
- select account chat model (e9900a6)
- load account credential requirements (059d4e3)
- provision account model credentials (ac62a0e)
- persist repository login for test accounts (2facfbd)
- preserve combined browser authentication (fe30022)
- prepare app login before browser tests (fb22b96)
- defer QA user identity lookup (bb888db)
- retry temporary QA login failures (a55b70f)
- stop after valid capability output (2c872bd)
- prepare authenticated QA browser (d1dfe99)
- route automatic models through fallback gateway (9979d17)

### Chores
- release 0.4.597 (2711d59)

The release orchestrator will merge this into `main` and continue to publish + deploy.