### PR TITLE
chore: release v0.4.617

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.4.617 — 2026-08-22
+
+### Fixes
+- identify engine package repository (a8674d1)
+- enable trusted npm publishing (6538e43)
+- use workflow identity for live chat storage (76ac32b)
+- preserve npm trusted publishing identity (b7061ad)
+- skip dependency install for config-only consumers (9750d2f)
+
+### Refactoring
+- publish engine through kody workflow (fe98ad5)
+
+### Chores
+- restore release CI lint gate (89b89e4)
+
+### Other
+- organize chat store imports (f75a2a2)
 ## v0.4.615 — 2026-08-22
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kody-ade/kody-engine",
-  "version": "0.4.616",
+  "version": "0.4.617",
   "description": "kody \u2014 autonomous development engine. Single-session Claude Code agent behind a generic executor + declarative implementation profiles.",
   "repository": {
     "type": "git",
@@ -60,10 +60,6 @@
   },
   "engines": {
     "node": ">=22"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/aharonyaircohen/kody-engine.git"
   },
   "homepage": "https://github.com/aharonyaircohen/kody-engine",
   "bugs": "https://github.com/aharonyaircohen/kody-engine/issues"


### PR DESCRIPTION
Automated release PR opened by kody.

## v0.4.617 — 2026-08-22

### Fixes
- identify engine package repository (a8674d1)
- enable trusted npm publishing (6538e43)
- use workflow identity for live chat storage (76ac32b)
- preserve npm trusted publishing identity (b7061ad)
- skip dependency install for config-only consumers (9750d2f)

### Refactoring
- publish engine through kody workflow (fe98ad5)

### Chores
- restore release CI lint gate (89b89e4)

### Other
- organize chat store imports (f75a2a2)

The release orchestrator will merge this into `main` and continue to publish + deploy.