### PR TITLE
fix: make live director reconciliation deterministic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kody-ade/kody-engine",
-  "version": "0.4.641",
+  "version": "0.4.642",
   "description": "kody — autonomous development engine. Single-session Claude Code agent behind a generic executor + declarative implementation profiles.",
   "license": "MIT",
   "repository": {

--- a/src/capabilityMcp.ts
+++ b/src/capabilityMcp.ts
@@ -517,6 +517,23 @@ export function startCapability(
   return dispatchWorkflow(workflowFile, name, forwardedIssue, repoSlug, ref)
 }
 
+export interface WorkflowRunStatus {
+  runId: number
+  status: string
+  conclusion: string | null
+  url: string
+  createdAt: string
+  updatedAt: string
+}
+
+export function readWorkflowRun(repoSlug: string, runId: number): WorkflowRunStatus {
+  const run = JSON.parse(
+    gh(["run", "view", String(runId), "--repo", repoSlug, "--json", "status,conclusion,url,createdAt,updatedAt"]),
+  ) as Omit<WorkflowRunStatus, "runId">
+
+  return { runId, ...run }
+}
+
 function capabilityAcceptsIssue(capability: string): boolean | null {
   const route = resolveCapabilityAction(capability)
   if (!route) return null
@@ -766,6 +783,18 @@ export function capabilityToolDefinitions(opts: CapabilityMcpOptions): Capabilit
     },
   }
 
+  const readWorkflowRunTool: CapabilityToolDefinition = {
+    name: "read_workflow_run",
+    description: "Read the current status and conclusion of an asynchronously started GitHub Actions workflow run.",
+    inputSchema: {
+      runId: z.number().int().positive(),
+    },
+    handler: async (args) => {
+      const result = readWorkflowRun(opts.repoSlug, Number(args.runId))
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] }
+    },
+  }
+
   const readLatestReportTool: CapabilityToolDefinition = {
     name: "read_latest_report",
     description:
@@ -812,9 +841,13 @@ export function capabilityToolDefinitions(opts: CapabilityMcpOptions): Capabilit
   const reconcileTodoTool: CapabilityToolDefinition = {
     name: "reconcile_todo",
     description:
-      "Idempotently create, update, close, or reopen one canonical repository Todo for a recurring problem. The stable slug and item id prevent duplicates. Repeating the same state is a no-op; unrelated items in an existing Todo are preserved.",
+      "Idempotently create, update, close, or reopen one canonical repository Todo for a recurring problem. The Todo family is derived from reportSlug and the stable item id prevents duplicates. Repeating the same state is a no-op; unrelated items in an existing Todo are preserved.",
     inputSchema: {
-      slug: z.string().regex(/^[a-z0-9][a-z0-9_-]{0,63}$/),
+      slug: z
+        .string()
+        .regex(/^[a-z0-9][a-z0-9_-]{0,63}$/)
+        .optional()
+        .describe("Deprecated; the canonical Todo slug is reportSlug."),
       itemId: z
         .string()
         .regex(/^[a-z0-9][a-z0-9_-]{0,79}$/)
@@ -827,12 +860,12 @@ export function capabilityToolDefinitions(opts: CapabilityMcpOptions): Capabilit
       evidence: z.string().max(20_000).optional(),
     },
     handler: async (args) => {
-      const slug = String(args.slug)
+      const reportSlug = String(args.reportSlug)
+      const slug = reportSlug
       const itemId = typeof args.itemId === "string" ? args.itemId : "finding"
       const title = String(args.title).trim()
       const description = typeof args.description === "string" ? args.description.trim() : ""
       const status = args.status === "resolved" ? "resolved" : "open"
-      const reportSlug = String(args.reportSlug)
       const reportRunId = typeof args.reportRunId === "string" ? args.reportRunId : undefined
       const evidence = typeof args.evidence === "string" ? args.evidence.trim() : ""
       const backend = createStateBackendFromEnv()
@@ -956,6 +989,7 @@ export function capabilityToolDefinitions(opts: CapabilityMcpOptions): Capabilit
     ensureIssueTool,
     ensureCommentTool,
     startCapabilityTool,
+    readWorkflowRunTool,
     readLatestReportTool,
     reconcileTodoTool,
     ...cmsTools,
@@ -998,6 +1032,7 @@ export const CAPABILITY_MCP_TOOL_NAMES = [
   "ensure_issue",
   "ensure_comment",
   "start_capability",
+  "read_workflow_run",
   "read_latest_report",
   "reconcile_todo",
   ...DASHBOARD_CMS_MCP_TOOL_NAMES,

--- a/src/implementations/live-agent/profile.json
+++ b/src/implementations/live-agent/profile.json
@@ -16,6 +16,7 @@
     "enableSubmitTool": true,
     "tools": [
       "mcp__kody-capability__start_capability",
+      "mcp__kody-capability__read_workflow_run",
       "mcp__kody-capability__read_latest_report",
       "mcp__kody-capability__reconcile_todo",
       "mcp__kody-submit__submit_state"

--- a/src/scripts/loadLiveAgent.ts
+++ b/src/scripts/loadLiveAgent.ts
@@ -102,7 +102,7 @@ export const loadLiveAgent: PreflightScript = async (ctx, profile) => {
     },
   }
   ctx.data.jobStateJson = JSON.stringify(state, null, 2)
-  ctx.data.capabilityTools = ["start_capability", "read_latest_report", "reconcile_todo"]
+  ctx.data.capabilityTools = ["start_capability", "read_workflow_run", "read_latest_report", "reconcile_todo"]
   ctx.data.capabilityToolMode = "lock"
   profile.claudeCode.enableSubmitTool = true
 }

--- a/tests/unit/liveAgentManagementTools.test.ts
+++ b/tests/unit/liveAgentManagementTools.test.ts
@@ -5,11 +5,13 @@ const backend = vi.hoisted(() => ({
   getRepoDoc: vi.fn(),
   saveRepoDoc: vi.fn(),
 }))
+const gh = vi.hoisted(() => vi.fn())
 
 vi.mock("../../src/state-backend.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../src/state-backend.js")>()
   return { ...actual, createStateBackendFromEnv: () => backend }
 })
+vi.mock("../../src/issue.js", () => ({ gh }))
 
 import { capabilityToolDefinitions } from "../../src/capabilityMcp.js"
 
@@ -28,6 +30,38 @@ function outputText(value: Awaited<ReturnType<ReturnType<typeof tool>["handler"]
 
 describe("live Agent management tools", () => {
   beforeEach(() => vi.clearAllMocks())
+
+  it("reads the real status of an asynchronously started workflow run", async () => {
+    gh.mockReturnValue(
+      JSON.stringify({
+        status: "completed",
+        conclusion: "success",
+        url: "https://github.com/acme/widgets/actions/runs/42",
+        createdAt: "2026-08-30T07:17:31Z",
+        updatedAt: "2026-08-30T07:18:58Z",
+      }),
+    )
+
+    const result = await tool("read_workflow_run").handler({ runId: 42 })
+
+    expect(JSON.parse(outputText(result))).toEqual({
+      runId: 42,
+      status: "completed",
+      conclusion: "success",
+      url: "https://github.com/acme/widgets/actions/runs/42",
+      createdAt: "2026-08-30T07:17:31Z",
+      updatedAt: "2026-08-30T07:18:58Z",
+    })
+    expect(gh).toHaveBeenCalledWith([
+      "run",
+      "view",
+      "42",
+      "--repo",
+      "acme/widgets",
+      "--json",
+      "status,conclusion,url,createdAt,updatedAt",
+    ])
+  })
 
   it("returns the newest matching Report", async () => {
     backend.listReports.mockResolvedValue([
@@ -74,6 +108,35 @@ describe("live Agent management tools", () => {
 
     expect(JSON.parse(outputText(repeated))).toMatchObject({ changed: false })
     expect(backend.saveRepoDoc).not.toHaveBeenCalled()
+  })
+
+  it("derives the canonical Todo from the Report instead of a generated slug", async () => {
+    let stored: Record<string, unknown> | null = null
+    backend.getRepoDoc.mockImplementation(async () => (stored ? { doc: stored, updatedAt: "revision-1" } : null))
+    backend.saveRepoDoc.mockImplementation(async (_tenant, _kind, doc) => {
+      stored = doc as Record<string, unknown>
+    })
+
+    const result = await tool("reconcile_todo").handler({
+      slug: "repo-ci-health",
+      itemId: "repo-ci-main",
+      title: "Repository CI health",
+      status: "open",
+      reportSlug: "director-repo-ci",
+      reportRunId: "run-1",
+      evidence: "CI is failing",
+    })
+
+    expect(JSON.parse(outputText(result))).toMatchObject({
+      changed: true,
+      slug: "director-repo-ci",
+    })
+    expect(backend.saveRepoDoc).toHaveBeenCalledWith(
+      "acme/widgets",
+      "todo:director-repo-ci",
+      expect.any(Object),
+      undefined,
+    )
   })
 
   it("verifies the Todo write and retries when the first write is not visible", async () => {

--- a/tests/unit/liveAgentRuntime.test.ts
+++ b/tests/unit/liveAgentRuntime.test.ts
@@ -91,7 +91,12 @@ describe("live Agent runtime", () => {
       liveAgentPreviousRevision: 4,
     })
     expect((data.jobState as { state: unknown }).state).toMatchObject({ rev: 4, cursor: "waiting", data: { run: 3 } })
-    expect(data.capabilityTools).toEqual(["start_capability", "read_latest_report", "reconcile_todo"])
+    expect(data.capabilityTools).toEqual([
+      "start_capability",
+      "read_workflow_run",
+      "read_latest_report",
+      "reconcile_todo",
+    ])
   })
 
   it("persists the submitted continuation with optimistic revision protection", async () => {


### PR DESCRIPTION
## Summary
- add a generic workflow-run status tool for live agents
- derive canonical Todo identity from the source Report
- expose the new tool to the live-agent runtime

## Verification
- lint and build pass
- 2,291 Engine tests pass with configured Store definitions
- new regression tests cover completed async runs and Todo deduplication