### PR TITLE
fix: enforce stable Director Todo items

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kody-ade/kody-engine",
-  "version": "0.4.642",
+  "version": "0.4.643",
   "description": "kody — autonomous development engine. Single-session Claude Code agent behind a generic executor + declarative implementation profiles.",
   "license": "MIT",
   "repository": {

--- a/src/capabilityMcp.ts
+++ b/src/capabilityMcp.ts
@@ -848,10 +848,7 @@ export function capabilityToolDefinitions(opts: CapabilityMcpOptions): Capabilit
         .regex(/^[a-z0-9][a-z0-9_-]{0,63}$/)
         .optional()
         .describe("Deprecated; the canonical Todo slug is reportSlug."),
-      itemId: z
-        .string()
-        .regex(/^[a-z0-9][a-z0-9_-]{0,79}$/)
-        .optional(),
+      itemId: z.string().regex(/^[a-z0-9][a-z0-9_-]{0,79}$/),
       title: z.string().min(1).max(160),
       description: z.string().max(20_000).optional(),
       status: z.enum(["open", "resolved"]),
@@ -862,7 +859,7 @@ export function capabilityToolDefinitions(opts: CapabilityMcpOptions): Capabilit
     handler: async (args) => {
       const reportSlug = String(args.reportSlug)
       const slug = reportSlug
-      const itemId = typeof args.itemId === "string" ? args.itemId : "finding"
+      const itemId = String(args.itemId)
       const title = String(args.title).trim()
       const description = typeof args.description === "string" ? args.description.trim() : ""
       const status = args.status === "resolved" ? "resolved" : "open"
@@ -885,13 +882,24 @@ export function capabilityToolDefinitions(opts: CapabilityMcpOptions): Capabilit
                 Boolean(item && typeof item === "object" && !Array.isArray(item)),
               )
             : []
-          const previous = currentItems.find((item) => item.id === itemId)
+          const isLegacyFallbackForReport = (item: Record<string, unknown>) => {
+            if (itemId === "finding" || item.id !== "finding") return false
+            const meta =
+              item.meta && typeof item.meta === "object" && !Array.isArray(item.meta)
+                ? (item.meta as Record<string, unknown>)
+                : {}
+            return meta.reportSlug === reportSlug
+          }
+          const removedLegacyFallback = currentItems.some(isLegacyFallbackForReport)
+          const canonicalItems = currentItems.filter((item) => !isLegacyFallbackForReport(item))
+          const previous = canonicalItems.find((item) => item.id === itemId)
           const previousMeta =
             previous?.meta && typeof previous.meta === "object" && !Array.isArray(previous.meta)
               ? (previous.meta as Record<string, unknown>)
               : {}
           const unchanged = Boolean(
             previous &&
+              !removedLegacyFallback &&
               previous.completed === completed &&
               previous.title === title &&
               String(previous.body ?? "") === evidence &&
@@ -919,8 +927,8 @@ export function capabilityToolDefinitions(opts: CapabilityMcpOptions): Capabilit
             },
           }
           const items = previous
-            ? currentItems.map((item) => (item.id === itemId ? nextItem : item))
-            : [...currentItems, nextItem]
+            ? canonicalItems.map((item) => (item.id === itemId ? nextItem : item))
+            : [...canonicalItems, nextItem]
           const doc = {
             ...current,
             version: 1,

--- a/tests/unit/liveAgentManagementTools.test.ts
+++ b/tests/unit/liveAgentManagementTools.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { z } from "zod"
 
 const backend = vi.hoisted(() => ({
   listReports: vi.fn(),
@@ -30,6 +31,12 @@ function outputText(value: Awaited<ReturnType<ReturnType<typeof tool>["handler"]
 
 describe("live Agent management tools", () => {
   beforeEach(() => vi.clearAllMocks())
+
+  it("requires a stable Todo item id", () => {
+    const itemIdSchema = tool("reconcile_todo").inputSchema.itemId
+
+    expect(z.safeParse(itemIdSchema, undefined).success).toBe(false)
+  })
 
   it("reads the real status of an asynchronously started workflow run", async () => {
     gh.mockReturnValue(
@@ -83,6 +90,7 @@ describe("live Agent management tools", () => {
     })
     const input = {
       slug: "director-repo-ci",
+      itemId: "repo-ci-main",
       title: "Restore repository CI",
       status: "open",
       reportSlug: "director-repo-ci",
@@ -97,7 +105,7 @@ describe("live Agent management tools", () => {
       "acme/widgets",
       "todo:director-repo-ci",
       expect.objectContaining({
-        items: [expect.objectContaining({ id: "finding", completed: false })],
+        items: [expect.objectContaining({ id: "repo-ci-main", completed: false })],
       }),
       undefined,
     )
@@ -137,6 +145,45 @@ describe("live Agent management tools", () => {
       expect.any(Object),
       undefined,
     )
+  })
+
+  it("collapses the legacy fallback item for the same Report", async () => {
+    let stored: Record<string, unknown> = {
+      version: 1,
+      title: "Repository CI health",
+      items: [
+        {
+          id: "finding",
+          title: "Legacy CI finding",
+          completed: true,
+          meta: { reportSlug: "director-repo-ci", reportRunId: "old-run" },
+        },
+        {
+          id: "unrelated",
+          title: "Keep me",
+          completed: false,
+          meta: { reportSlug: "another-report" },
+        },
+      ],
+    }
+    backend.getRepoDoc.mockImplementation(async () => ({ doc: stored, updatedAt: "revision-1" }))
+    backend.saveRepoDoc.mockImplementation(async (_tenant, _kind, doc) => {
+      stored = doc as Record<string, unknown>
+    })
+
+    await tool("reconcile_todo").handler({
+      itemId: "repo-ci-main",
+      title: "Repository CI health",
+      status: "resolved",
+      reportSlug: "director-repo-ci",
+      reportRunId: "new-run",
+      evidence: "CI is healthy",
+    })
+
+    expect((stored.items as Array<Record<string, unknown>>).map((item) => item.id)).toEqual([
+      "unrelated",
+      "repo-ci-main",
+    ])
   })
 
   it("verifies the Todo write and retries when the first write is not visible", async () => {
@@ -188,6 +235,7 @@ describe("live Agent management tools", () => {
 
     await tool("reconcile_todo").handler({
       slug: "director-repo-ci",
+      itemId: "repo-ci-main",
       title: "Restore repository CI",
       status: "resolved",
       reportSlug: "director-repo-ci",
@@ -195,11 +243,12 @@ describe("live Agent management tools", () => {
     })
 
     const closed = backend.saveRepoDoc.mock.calls[0]![2]
-    expect(closed.items).toEqual([expect.objectContaining({ id: "finding", completed: true })])
+    expect(closed.items).toEqual([expect.objectContaining({ id: "repo-ci-main", completed: true })])
 
     backend.saveRepoDoc.mockClear()
     await tool("reconcile_todo").handler({
       slug: "director-repo-ci",
+      itemId: "repo-ci-main",
       title: "Restore repository CI",
       status: "open",
       reportSlug: "director-repo-ci",
@@ -207,6 +256,8 @@ describe("live Agent management tools", () => {
     })
 
     const reopened = backend.saveRepoDoc.mock.calls[0]![2]
-    expect(reopened.items).toEqual([expect.objectContaining({ id: "finding", completed: false, completedAt: null })])
+    expect(reopened.items).toEqual([
+      expect.objectContaining({ id: "repo-ci-main", completed: false, completedAt: null }),
+    ])
   })
 })


### PR DESCRIPTION
## Summary
- require a stable item ID for recurring Todo reconciliation
- collapse the legacy fallback item only when it belongs to the same Report
- preserve unrelated Todo items

## Verification
- focused live-agent tests
- lint
- build
- full test suite